### PR TITLE
feat: Replace -soon to be deprecated- cchain.explorer links with snow…

### DIFF
--- a/projects/benqi.json
+++ b/projects/benqi.json
@@ -7,7 +7,7 @@
     "type": "governance",
     "description": "Logic for the QI governance token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5",
+      "https://snowtrace.io/address/0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5",
       "https://avascan.info/blockchain/c/address/0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5"
     ]
   },
@@ -19,7 +19,7 @@
     "type": "core",
     "description": "Logic for the LINK market and its qiLINK token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4e9f683A27a6BdAD3FC2764003759277e93696e6",
+      "https://snowtrace.io/address/0x4e9f683A27a6BdAD3FC2764003759277e93696e6",
       "https://avascan.info/blockchain/c/address/0x4e9f683A27a6BdAD3FC2764003759277e93696e6"
     ]
   },
@@ -31,7 +31,7 @@
     "type": "core",
     "description": "Logic for the USDT market and its qiUSDT token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc9e5999b8e75C3fEB117F6f73E664b9f3C8ca65C",
+      "https://snowtrace.io/address/0xc9e5999b8e75C3fEB117F6f73E664b9f3C8ca65C",
       "https://avascan.info/blockchain/c/address/0xc9e5999b8e75C3fEB117F6f73E664b9f3C8ca65C"
     ]
   },
@@ -43,7 +43,7 @@
     "type": "core",
     "description": "Logic for the AVAX market and its qiAVAX token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5C0401e81Bc07Ca70fAD469b451682c0d747Ef1c",
+      "https://snowtrace.io/address/0x5C0401e81Bc07Ca70fAD469b451682c0d747Ef1c",
       "https://avascan.info/blockchain/c/address/0x5C0401e81Bc07Ca70fAD469b451682c0d747Ef1c"
     ]
   },
@@ -55,7 +55,7 @@
     "type": "core",
     "description": "Logic for the BTC market and its qiBTC token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe194c4c5aC32a3C9ffDb358d9Bfd523a0B6d1568",
+      "https://snowtrace.io/address/0xe194c4c5aC32a3C9ffDb358d9Bfd523a0B6d1568",
       "https://avascan.info/blockchain/c/address/0xe194c4c5aC32a3C9ffDb358d9Bfd523a0B6d1568"
     ]
   },
@@ -67,7 +67,7 @@
     "type": "core",
     "description": "Logic for the ETH market and its qiETH token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x334AD834Cd4481BB02d09615E7c11a00579A7909",
+      "https://snowtrace.io/address/0x334AD834Cd4481BB02d09615E7c11a00579A7909",
       "https://avascan.info/blockchain/c/address/0x334AD834Cd4481BB02d09615E7c11a00579A7909"
     ]
   },
@@ -79,7 +79,7 @@
     "type": "core",
     "description": "Logic for the DAI market and its qiDAI token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x835866d37AFB8CB8F8334dCCdaf66cf01832Ff5D",
+      "https://snowtrace.io/address/0x835866d37AFB8CB8F8334dCCdaf66cf01832Ff5D",
       "https://avascan.info/blockchain/c/address/0x835866d37AFB8CB8F8334dCCdaf66cf01832Ff5D"
     ]
   },
@@ -91,7 +91,7 @@
     "type": "core",
     "description": "Logic for the USDC market and its qiUSDC token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xBEb5d47A3f720Ec0a390d04b4d41ED7d9688bC7F",
+      "https://snowtrace.io/address/0xBEb5d47A3f720Ec0a390d04b4d41ED7d9688bC7F",
       "https://avascan.info/blockchain/c/address/0xBEb5d47A3f720Ec0a390d04b4d41ED7d9688bC7F"
     ]
   },
@@ -103,7 +103,7 @@
     "type": "core",
     "description": "Logic for the QI market and its qiQI token",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x35Bd6aedA81a7E5FC7A7832490e71F757b0cD9Ce",
+      "https://snowtrace.io/address/0x35Bd6aedA81a7E5FC7A7832490e71F757b0cD9Ce",
       "https://avascan.info/blockchain/c/address/0x35Bd6aedA81a7E5FC7A7832490e71F757b0cD9Ce"
     ]
   },
@@ -115,7 +115,7 @@
     "type": "governance",
     "description": "Logic for the central controller for the markets",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x486Af39519B4Dc9a7fCcd318217352830E8AD9b4",
+      "https://snowtrace.io/address/0x486Af39519B4Dc9a7fCcd318217352830E8AD9b4",
       "https://avascan.info/blockchain/c/address/0x486Af39519B4Dc9a7fCcd318217352830E8AD9b4"
     ]
   }

--- a/projects/sushiswap.json
+++ b/projects/sushiswap.json
@@ -315,7 +315,7 @@
     "type": "core",
     "description": "Deploys Sushiswap V2 pools",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4/transactions"
+      "https://snowtrace.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4/transactions"
     ]
   },
   {
@@ -326,7 +326,7 @@
     "type": "core",
     "description": "Supports trading and liquidity management tasks",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506/transactions"
+      "https://snowtrace.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506/transactions"
     ]
   }
 ]

--- a/projects/trader-joe.json
+++ b/projects/trader-joe.json
@@ -7,7 +7,7 @@
     "type": "governance",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd/transactions"
+      "https://snowtrace.io/address/0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd/transactions"
     ]
   },
   {
@@ -18,7 +18,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x57319d41f71e81f3c65f2a47ca4e001ebafd4f33/transactions"
+      "https://snowtrace.io/address/0x57319d41f71e81f3c65f2a47ca4e001ebafd4f33/transactions"
     ]
   },
   {
@@ -29,7 +29,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9ad6c38be94206ca50bb0d90783181662f0cfa10/transactions"
+      "https://snowtrace.io/address/0x9ad6c38be94206ca50bb0d90783181662f0cfa10/transactions"
     ]
   },
   {
@@ -40,7 +40,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x60ae616a2155ee3d9a68541ba4544862310933d4/transactions"
+      "https://snowtrace.io/address/0x60ae616a2155ee3d9a68541ba4544862310933d4/transactions"
     ]
   },
   {
@@ -51,7 +51,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd6a4f121ca35509af06a0be99093d08462f53052/transactions"
+      "https://snowtrace.io/address/0xd6a4f121ca35509af06a0be99093d08462f53052/transactions"
     ]
   },
   {
@@ -62,7 +62,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x188bed1968b795d5c9022f6a0bb5931ac4c18f00/transactions"
+      "https://snowtrace.io/address/0x188bed1968b795d5c9022f6a0bb5931ac4c18f00/transactions"
     ]
   },
   {
@@ -73,7 +73,7 @@
     "type": "governance",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xadaf18d79f316005542da4ecb1624b59c4e6e398/transactions"
+      "https://snowtrace.io/address/0xadaf18d79f316005542da4ecb1624b59c4e6e398/transactions"
     ]
   },
   {
@@ -84,7 +84,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x82fe038ea4b50f9c957da326c412ebd73462077c/transactions"
+      "https://snowtrace.io/address/0x82fe038ea4b50f9c957da326c412ebd73462077c/transactions"
     ]
   },
   {
@@ -95,7 +95,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaff90532e2937ff290009521e7e120ed062d4f34/transactions"
+      "https://snowtrace.io/address/0xaff90532e2937ff290009521e7e120ed062d4f34/transactions"
     ]
   },
   {
@@ -106,7 +106,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc13b1c927565c5af8fcaf9ef7387172c447f6796/transactions"
+      "https://snowtrace.io/address/0xc13b1c927565c5af8fcaf9ef7387172c447f6796/transactions"
     ]
   },
   {
@@ -117,7 +117,7 @@
     "type": "governance",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdc13687554205e5b89ac783db14bb5bba4a1edac/transactions"
+      "https://snowtrace.io/address/0xdc13687554205e5b89ac783db14bb5bba4a1edac/transactions"
     ]
   },
   {
@@ -128,7 +128,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe34309613b061545d42c4160ec4d64240b114482/transactions"
+      "https://snowtrace.io/address/0xe34309613b061545d42c4160ec4d64240b114482/transactions"
     ]
   },
   {
@@ -139,7 +139,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2274491950b2d6d79b7e69b683b482282ba14885/transactions"
+      "https://snowtrace.io/address/0x2274491950b2d6d79b7e69b683b482282ba14885/transactions"
     ]
   },
   {
@@ -150,7 +150,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe6ffd92b9f77fbf5bfec0f3d9c9d027c4cf3ba6e/transactions"
+      "https://snowtrace.io/address/0xe6ffd92b9f77fbf5bfec0f3d9c9d027c4cf3ba6e/transactions"
     ]
   },
   {
@@ -161,7 +161,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3c5486b85faae29b071f2a616a59ca7bf8f73682/transactions"
+      "https://snowtrace.io/address/0x3c5486b85faae29b071f2a616a59ca7bf8f73682/transactions"
     ]
   },
   {
@@ -172,7 +172,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x82ea6f7bf853a199ab921137b119b6d41f08038e/transactions"
+      "https://snowtrace.io/address/0x82ea6f7bf853a199ab921137b119b6d41f08038e/transactions"
     ]
   },
   {
@@ -183,7 +183,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x997fba28c75747417571c5f3fe50015aac2bb073/transactions"
+      "https://snowtrace.io/address/0x997fba28c75747417571c5f3fe50015aac2bb073/transactions"
     ]
   },
   {
@@ -194,7 +194,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe5cddafd0f7af3deaf4bd213bbaee7a5927ab7e7/transactions"
+      "https://snowtrace.io/address/0xe5cddafd0f7af3deaf4bd213bbaee7a5927ab7e7/transactions"
     ]
   },
   {
@@ -205,7 +205,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc22f01ddc8010ee05574028528614634684ec29e/transactions"
+      "https://snowtrace.io/address/0xc22f01ddc8010ee05574028528614634684ec29e/transactions"
     ]
   },
   {
@@ -216,7 +216,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x929f5cab61dfec79a5431a7734a68d714c4633fa/transactions"
+      "https://snowtrace.io/address/0x929f5cab61dfec79a5431a7734a68d714c4633fa/transactions"
     ]
   },
   {
@@ -227,7 +227,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3fe38b7b610c0acd10296fef69d9b18eb7a9eb1f/transactions"
+      "https://snowtrace.io/address/0x3fe38b7b610c0acd10296fef69d9b18eb7a9eb1f/transactions"
     ]
   },
   {
@@ -238,7 +238,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xed6aaf91a2b084bd594dbd1245be3691f9f637ac/transactions"
+      "https://snowtrace.io/address/0xed6aaf91a2b084bd594dbd1245be3691f9f637ac/transactions"
     ]
   },
   {
@@ -249,7 +249,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8b650e26404ac6837539ca96812f0123601e4448/transactions"
+      "https://snowtrace.io/address/0x8b650e26404ac6837539ca96812f0123601e4448/transactions"
     ]
   },
   {
@@ -260,7 +260,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc988c170d0e38197dc634a45bf00169c7aa7ca19/transactions"
+      "https://snowtrace.io/address/0xc988c170d0e38197dc634a45bf00169c7aa7ca19/transactions"
     ]
   },
   {
@@ -271,7 +271,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x585e7bc75089ed111b656faa7aeb1104f5b96c15/transactions"
+      "https://snowtrace.io/address/0x585e7bc75089ed111b656faa7aeb1104f5b96c15/transactions"
     ]
   },
   {
@@ -282,7 +282,7 @@
     "type": "core",
     "description": "-",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xce095a9657a02025081e0607c8d8b081c76a75ea/transactions"
+      "https://snowtrace.io/address/0xce095a9657a02025081e0607c8d8b081c76a75ea/transactions"
     ]
   }
 ]

--- a/projects/yield-yak.json
+++ b/projects/yield-yak.json
@@ -7,7 +7,7 @@
     "type": "core",
     "description": "BAG farm for compounding BAG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf487044ed85f2d47a8ead6b86c834976b8c31736",
+      "https://snowtrace.io/address/0xf487044ed85f2d47a8ead6b86c834976b8c31736",
       "https://avascan.info/blockchain/c/address/0xf487044ed85f2d47a8ead6b86c834976b8c31736"
     ]
   },
@@ -19,7 +19,7 @@
     "type": "core",
     "description": "BAG farm for compounding QI",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8dc3cf91d0118121b5f152556e8e33804c1ae1cd",
+      "https://snowtrace.io/address/0x8dc3cf91d0118121b5f152556e8e33804c1ae1cd",
       "https://avascan.info/blockchain/c/address/0x8dc3cf91d0118121b5f152556e8e33804c1ae1cd"
     ]
   },
@@ -31,7 +31,7 @@
     "type": "core",
     "description": "BAG farm for compounding QI",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x976c480a2838eb668c502f9087765ed93e3cf892",
+      "https://snowtrace.io/address/0x976c480a2838eb668c502f9087765ed93e3cf892",
       "https://avascan.info/blockchain/c/address/0x976c480a2838eb668c502f9087765ed93e3cf892"
     ]
   },
@@ -43,7 +43,7 @@
     "type": "core",
     "description": "BAG farm for compounding WAVAX",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x58887009a412ad52a4fb746d0846585346d83bc0",
+      "https://snowtrace.io/address/0x58887009a412ad52a4fb746d0846585346d83bc0",
       "https://avascan.info/blockchain/c/address/0x58887009a412ad52a4fb746d0846585346d83bc0"
     ]
   },
@@ -55,7 +55,7 @@
     "type": "core",
     "description": "BAG farm for compounding XAVA",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x562acea3c03dbddc25e2f24bb2685d17bdb4e62f",
+      "https://snowtrace.io/address/0x562acea3c03dbddc25e2f24bb2685d17bdb4e62f",
       "https://avascan.info/blockchain/c/address/0x562acea3c03dbddc25e2f24bb2685d17bdb4e62f"
     ]
   },
@@ -67,7 +67,7 @@
     "type": "core",
     "description": "BAMBOO farm for compounding BAMBOO",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1ad3be171a6be9f6b9a60c30c5373185bd9c0b6e",
+      "https://snowtrace.io/address/0x1ad3be171a6be9f6b9a60c30c5373185bd9c0b6e",
       "https://avascan.info/blockchain/c/address/0x1ad3be171a6be9f6b9a60c30c5373185bd9c0b6e"
     ]
   },
@@ -79,7 +79,7 @@
     "type": "core",
     "description": "BENQI farm for compounding AVAX",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8b414448de8b609e96bd63dcf2a8adbd5ddf7fdd",
+      "https://snowtrace.io/address/0x8b414448de8b609e96bd63dcf2a8adbd5ddf7fdd",
       "https://avascan.info/blockchain/c/address/0x8b414448de8b609e96bd63dcf2a8adbd5ddf7fdd"
     ]
   },
@@ -91,7 +91,7 @@
     "type": "core",
     "description": "BENQI farm for compounding DAIe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9669fe1ea0d8883661289461b90a10b71ae400ee",
+      "https://snowtrace.io/address/0x9669fe1ea0d8883661289461b90a10b71ae400ee",
       "https://avascan.info/blockchain/c/address/0x9669fe1ea0d8883661289461b90a10b71ae400ee"
     ]
   },
@@ -103,7 +103,7 @@
     "type": "core",
     "description": "BENQI farm for compounding LINKe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4084f32a91f4d8636ca08386efe70c6e302f1d84",
+      "https://snowtrace.io/address/0x4084f32a91f4d8636ca08386efe70c6e302f1d84",
       "https://avascan.info/blockchain/c/address/0x4084f32a91f4d8636ca08386efe70c6e302f1d84"
     ]
   },
@@ -115,7 +115,7 @@
     "type": "core",
     "description": "BENQI farm for compounding QI",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbf5bffbf7d94d3b29abe6eb20089b8a9e3d229f7",
+      "https://snowtrace.io/address/0xbf5bffbf7d94d3b29abe6eb20089b8a9e3d229f7",
       "https://avascan.info/blockchain/c/address/0xbf5bffbf7d94d3b29abe6eb20089b8a9e3d229f7"
     ]
   },
@@ -127,7 +127,7 @@
     "type": "core",
     "description": "BENQI farm for compounding USDCe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfbdc6e63cf250e2843ffaef75717993b3d7ca89e",
+      "https://snowtrace.io/address/0xfbdc6e63cf250e2843ffaef75717993b3d7ca89e",
       "https://avascan.info/blockchain/c/address/0xfbdc6e63cf250e2843ffaef75717993b3d7ca89e"
     ]
   },
@@ -139,7 +139,7 @@
     "type": "core",
     "description": "BENQI farm for compounding USDTe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5bd57dfc6bc4fc322da4a4a4da9a0a05482644c2",
+      "https://snowtrace.io/address/0x5bd57dfc6bc4fc322da4a4a4da9a0a05482644c2",
       "https://avascan.info/blockchain/c/address/0x5bd57dfc6bc4fc322da4a4a4da9a0a05482644c2"
     ]
   },
@@ -151,7 +151,7 @@
     "type": "core",
     "description": "BENQI farm for compounding WBTCe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x755c78d3bc25e297e8e010a2d1fcf49cc43ada21",
+      "https://snowtrace.io/address/0x755c78d3bc25e297e8e010a2d1fcf49cc43ada21",
       "https://avascan.info/blockchain/c/address/0x755c78d3bc25e297e8e010a2d1fcf49cc43ada21"
     ]
   },
@@ -163,7 +163,7 @@
     "type": "core",
     "description": "BENQI farm for compounding WETHe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7d2d076000611e44740d636843384412399e31b9",
+      "https://snowtrace.io/address/0x7d2d076000611e44740d636843384412399e31b9",
       "https://avascan.info/blockchain/c/address/0x7d2d076000611e44740d636843384412399e31b9"
     ]
   },
@@ -175,7 +175,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa004785b6a53dd1f523d5519b5efdc619b6b92c5",
+      "https://snowtrace.io/address/0xa004785b6a53dd1f523d5519b5efdc619b6b92c5",
       "https://avascan.info/blockchain/c/address/0xa004785b6a53dd1f523d5519b5efdc619b6b92c5"
     ]
   },
@@ -187,7 +187,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8c3c86bea8ed5acbce4944def6731291eb193c26",
+      "https://snowtrace.io/address/0x8c3c86bea8ed5acbce4944def6731291eb193c26",
       "https://avascan.info/blockchain/c/address/0x8c3c86bea8ed5acbce4944def6731291eb193c26"
     ]
   },
@@ -199,7 +199,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfb5aa7660fde5013996fd72a193accf00212af32",
+      "https://snowtrace.io/address/0xfb5aa7660fde5013996fd72a193accf00212af32",
       "https://avascan.info/blockchain/c/address/0xfb5aa7660fde5013996fd72a193accf00212af32"
     ]
   },
@@ -211,7 +211,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfd1f86448b56942c32b954092f2fdbce91e37bf6",
+      "https://snowtrace.io/address/0xfd1f86448b56942c32b954092f2fdbce91e37bf6",
       "https://avascan.info/blockchain/c/address/0xfd1f86448b56942c32b954092f2fdbce91e37bf6"
     ]
   },
@@ -223,7 +223,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfc47515433ee291e692958a2d15f99896fafc0bc",
+      "https://snowtrace.io/address/0xfc47515433ee291e692958a2d15f99896fafc0bc",
       "https://avascan.info/blockchain/c/address/0xfc47515433ee291e692958a2d15f99896fafc0bc"
     ]
   },
@@ -235,7 +235,7 @@
     "type": "core",
     "description": "BGL farm for AVAX-XAVA LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x39f7fcb3af11b0a274514c581d468739e75f64ec",
+      "https://snowtrace.io/address/0x39f7fcb3af11b0a274514c581d468739e75f64ec",
       "https://avascan.info/blockchain/c/address/0x39f7fcb3af11b0a274514c581d468739e75f64ec"
     ]
   },
@@ -247,7 +247,7 @@
     "type": "core",
     "description": "BGL farm for BAG-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x908698b561ea14f153ddd1ee02f99ebe0a4cea0f",
+      "https://snowtrace.io/address/0x908698b561ea14f153ddd1ee02f99ebe0a4cea0f",
       "https://avascan.info/blockchain/c/address/0x908698b561ea14f153ddd1ee02f99ebe0a4cea0f"
     ]
   },
@@ -259,7 +259,7 @@
     "type": "core",
     "description": "BGL farm for BAG-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8bf6402afcfe11519947829af44770fa44a01949",
+      "https://snowtrace.io/address/0x8bf6402afcfe11519947829af44770fa44a01949",
       "https://avascan.info/blockchain/c/address/0x8bf6402afcfe11519947829af44770fa44a01949"
     ]
   },
@@ -271,7 +271,7 @@
     "type": "core",
     "description": "BGL farm for BAG-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbd9f16eee869808bf22823427d1f4a1e7a440e8d",
+      "https://snowtrace.io/address/0xbd9f16eee869808bf22823427d1f4a1e7a440e8d",
       "https://avascan.info/blockchain/c/address/0xbd9f16eee869808bf22823427d1f4a1e7a440e8d"
     ]
   },
@@ -283,7 +283,7 @@
     "type": "core",
     "description": "BGL farm for BAG-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x90e24a2dfd80f02d01c7b630e8e3199c8a0388d3",
+      "https://snowtrace.io/address/0x90e24a2dfd80f02d01c7b630e8e3199c8a0388d3",
       "https://avascan.info/blockchain/c/address/0x90e24a2dfd80f02d01c7b630e8e3199c8a0388d3"
     ]
   },
@@ -295,7 +295,7 @@
     "type": "core",
     "description": "BGL farm for BAG-LINKe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3ca2cfd8e17c40ac6f4aa6c1a4b1723f0bf59dd8",
+      "https://snowtrace.io/address/0x3ca2cfd8e17c40ac6f4aa6c1a4b1723f0bf59dd8",
       "https://avascan.info/blockchain/c/address/0x3ca2cfd8e17c40ac6f4aa6c1a4b1723f0bf59dd8"
     ]
   },
@@ -307,7 +307,7 @@
     "type": "core",
     "description": "BGL farm for BAG-QI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9ee89f3a3dfd596bb6f53696e2ed1d09c738f8c8",
+      "https://snowtrace.io/address/0x9ee89f3a3dfd596bb6f53696e2ed1d09c738f8c8",
       "https://avascan.info/blockchain/c/address/0x9ee89f3a3dfd596bb6f53696e2ed1d09c738f8c8"
     ]
   },
@@ -319,7 +319,7 @@
     "type": "core",
     "description": "BGL farm for BAG-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x165fa1023429e266cd767845e8de419ce3abd379",
+      "https://snowtrace.io/address/0x165fa1023429e266cd767845e8de419ce3abd379",
       "https://avascan.info/blockchain/c/address/0x165fa1023429e266cd767845e8de419ce3abd379"
     ]
   },
@@ -331,7 +331,7 @@
     "type": "core",
     "description": "BGL farm for BAG-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb940da8b71791c1f42cc612d1af427878ec1a369",
+      "https://snowtrace.io/address/0xb940da8b71791c1f42cc612d1af427878ec1a369",
       "https://avascan.info/blockchain/c/address/0xb940da8b71791c1f42cc612d1af427878ec1a369"
     ]
   },
@@ -343,7 +343,7 @@
     "type": "core",
     "description": "BGL farm for BAG-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8f871d05d7afb9daffa5df13a91c74e870e6c31e",
+      "https://snowtrace.io/address/0x8f871d05d7afb9daffa5df13a91c74e870e6c31e",
       "https://avascan.info/blockchain/c/address/0x8f871d05d7afb9daffa5df13a91c74e870e6c31e"
     ]
   },
@@ -355,7 +355,7 @@
     "type": "core",
     "description": "BGL farm for BAG-WET LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x211654525dc64a7f74f6361d6f3dc0710108ae43",
+      "https://snowtrace.io/address/0x211654525dc64a7f74f6361d6f3dc0710108ae43",
       "https://avascan.info/blockchain/c/address/0x211654525dc64a7f74f6361d6f3dc0710108ae43"
     ]
   },
@@ -367,7 +367,7 @@
     "type": "core",
     "description": "BGL farm for BAG-WETHe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x142b4e2c9234afc3dc07e12d24493a4ef26c537c",
+      "https://snowtrace.io/address/0x142b4e2c9234afc3dc07e12d24493a4ef26c537c",
       "https://avascan.info/blockchain/c/address/0x142b4e2c9234afc3dc07e12d24493a4ef26c537c"
     ]
   },
@@ -379,7 +379,7 @@
     "type": "core",
     "description": "BGL farm for BAG-XAVA LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb667121b4d4b6ea5de4bb61bd3a02e53529bfcca",
+      "https://snowtrace.io/address/0xb667121b4d4b6ea5de4bb61bd3a02e53529bfcca",
       "https://avascan.info/blockchain/c/address/0xb667121b4d4b6ea5de4bb61bd3a02e53529bfcca"
     ]
   },
@@ -391,7 +391,7 @@
     "type": "core",
     "description": "BGL farm for BAG-YAK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1b53500677cb1b042b12081a8661a6f08781d58c",
+      "https://snowtrace.io/address/0x1b53500677cb1b042b12081a8661a6f08781d58c",
       "https://avascan.info/blockchain/c/address/0x1b53500677cb1b042b12081a8661a6f08781d58c"
     ]
   },
@@ -403,7 +403,7 @@
     "type": "core",
     "description": "Helper files",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x70c9994bd1a5ea76279a8eedda756c064cc04026",
+      "https://snowtrace.io/address/0x70c9994bd1a5ea76279a8eedda756c064cc04026",
       "https://avascan.info/blockchain/c/address/0x70c9994bd1a5ea76279a8eedda756c064cc04026"
     ]
   },
@@ -415,7 +415,7 @@
     "type": "core",
     "description": "CLR farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5f349af20f87ec815301979fc9c434e2333641bf",
+      "https://snowtrace.io/address/0x5f349af20f87ec815301979fc9c434e2333641bf",
       "https://avascan.info/blockchain/c/address/0x5f349af20f87ec815301979fc9c434e2333641bf"
     ]
   },
@@ -427,7 +427,7 @@
     "type": "core",
     "description": "CLR farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x258ed410926b57dc45915a479f4cefa130e5378b",
+      "https://snowtrace.io/address/0x258ed410926b57dc45915a479f4cefa130e5378b",
       "https://avascan.info/blockchain/c/address/0x258ed410926b57dc45915a479f4cefa130e5378b"
     ]
   },
@@ -439,7 +439,7 @@
     "type": "core",
     "description": "CLR farm for AVAX-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1f257a6e8e4873cc32ae4e69d8436fe70c663fb7",
+      "https://snowtrace.io/address/0x1f257a6e8e4873cc32ae4e69d8436fe70c663fb7",
       "https://avascan.info/blockchain/c/address/0x1f257a6e8e4873cc32ae4e69d8436fe70c663fb7"
     ]
   },
@@ -451,7 +451,7 @@
     "type": "core",
     "description": "CLR farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc0c50ab019d256ec32023afdca6868c022977da2",
+      "https://snowtrace.io/address/0xc0c50ab019d256ec32023afdca6868c022977da2",
       "https://avascan.info/blockchain/c/address/0xc0c50ab019d256ec32023afdca6868c022977da2"
     ]
   },
@@ -463,7 +463,7 @@
     "type": "core",
     "description": "CNR farm for compounding CNR",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbd8b2bc5caab6843365084b529905964d0626248",
+      "https://snowtrace.io/address/0xbd8b2bc5caab6843365084b529905964d0626248",
       "https://avascan.info/blockchain/c/address/0xbd8b2bc5caab6843365084b529905964d0626248"
     ]
   },
@@ -475,7 +475,7 @@
     "type": "core",
     "description": "CNR farm for compounding WAVAX",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1fc1f7a0943c589edff4a3650e40c0821b41901d",
+      "https://snowtrace.io/address/0x1fc1f7a0943c589edff4a3650e40c0821b41901d",
       "https://avascan.info/blockchain/c/address/0x1fc1f7a0943c589edff4a3650e40c0821b41901d"
     ]
   },
@@ -487,7 +487,7 @@
     "type": "core",
     "description": "COM farm for AVAX-COM LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7f3bb8db336ff50120e290e5c8ec78b20f619d01",
+      "https://snowtrace.io/address/0x7f3bb8db336ff50120e290e5c8ec78b20f619d01",
       "https://avascan.info/blockchain/c/address/0x7f3bb8db336ff50120e290e5c8ec78b20f619d01"
     ]
   },
@@ -499,7 +499,7 @@
     "type": "core",
     "description": "COM farm for AVAX-XCOM LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfd410034f88b99e4bee8bd7b51fa323b6678bf73",
+      "https://snowtrace.io/address/0xfd410034f88b99e4bee8bd7b51fa323b6678bf73",
       "https://avascan.info/blockchain/c/address/0xfd410034f88b99e4bee8bd7b51fa323b6678bf73"
     ]
   },
@@ -511,7 +511,7 @@
     "type": "core",
     "description": "CRL farm for CNR-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x779a387e67af939a6e8e9cf664f69590763f9b06",
+      "https://snowtrace.io/address/0x779a387e67af939a6e8e9cf664f69590763f9b06",
       "https://avascan.info/blockchain/c/address/0x779a387e67af939a6e8e9cf664f69590763f9b06"
     ]
   },
@@ -523,7 +523,7 @@
     "type": "core",
     "description": "CRL farm for CNR-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7175a0271375283bd3dd363018a4db9ed73639e4",
+      "https://snowtrace.io/address/0x7175a0271375283bd3dd363018a4db9ed73639e4",
       "https://avascan.info/blockchain/c/address/0x7175a0271375283bd3dd363018a4db9ed73639e4"
     ]
   },
@@ -535,7 +535,7 @@
     "type": "core",
     "description": "CRL farm for CNR-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6094637c7a1b98ee136fa1aafabd59e7b0b514be",
+      "https://snowtrace.io/address/0x6094637c7a1b98ee136fa1aafabd59e7b0b514be",
       "https://avascan.info/blockchain/c/address/0x6094637c7a1b98ee136fa1aafabd59e7b0b514be"
     ]
   },
@@ -547,7 +547,7 @@
     "type": "core",
     "description": "CRL farm for CNR-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5da33bcd38fbc3e9632f9f6a198f4f0ef13746b6",
+      "https://snowtrace.io/address/0x5da33bcd38fbc3e9632f9f6a198f4f0ef13746b6",
       "https://avascan.info/blockchain/c/address/0x5da33bcd38fbc3e9632f9f6a198f4f0ef13746b6"
     ]
   },
@@ -559,7 +559,7 @@
     "type": "core",
     "description": "CRL farm for CNR-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb74de62eef4ebb0d02e60baf280f3c58080ec3c4",
+      "https://snowtrace.io/address/0xb74de62eef4ebb0d02e60baf280f3c58080ec3c4",
       "https://avascan.info/blockchain/c/address/0xb74de62eef4ebb0d02e60baf280f3c58080ec3c4"
     ]
   },
@@ -571,7 +571,7 @@
     "type": "core",
     "description": "CRL farm for YAK-CNR LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x316ad32f61eb06d537d1b545c5d4c5c2168baf6a",
+      "https://snowtrace.io/address/0x316ad32f61eb06d537d1b545c5d4c5c2168baf6a",
       "https://avascan.info/blockchain/c/address/0x316ad32f61eb06d537d1b545c5d4c5c2168baf6a"
     ]
   },
@@ -583,7 +583,7 @@
     "type": "core",
     "description": "CYCLE farm for DAIe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7d2da0917500afb3df94a09e24a34790a386b208",
+      "https://snowtrace.io/address/0x7d2da0917500afb3df94a09e24a34790a386b208",
       "https://avascan.info/blockchain/c/address/0x7d2da0917500afb3df94a09e24a34790a386b208"
     ]
   },
@@ -595,7 +595,7 @@
     "type": "core",
     "description": "CYCLE farm for USDCe-DAIe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x87099fde786144b554af66fb8cbe3130c8cb6470",
+      "https://snowtrace.io/address/0x87099fde786144b554af66fb8cbe3130c8cb6470",
       "https://avascan.info/blockchain/c/address/0x87099fde786144b554af66fb8cbe3130c8cb6470"
     ]
   },
@@ -607,7 +607,7 @@
     "type": "core",
     "description": "CYCLE farm for WETHe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3129fb69d734aebeeef7e40d33b5093f4284767c",
+      "https://snowtrace.io/address/0x3129fb69d734aebeeef7e40d33b5093f4284767c",
       "https://avascan.info/blockchain/c/address/0x3129fb69d734aebeeef7e40d33b5093f4284767c"
     ]
   },
@@ -619,7 +619,7 @@
     "type": "core",
     "description": "CYCLE farm for YAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x459f0df3d59554dcd82a26c0373789d7ed3e0c53",
+      "https://snowtrace.io/address/0x459f0df3d59554dcd82a26c0373789d7ed3e0c53",
       "https://avascan.info/blockchain/c/address/0x459f0df3d59554dcd82a26c0373789d7ed3e0c53"
     ]
   },
@@ -631,7 +631,7 @@
     "type": "core",
     "description": "CYCLE farm for QI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf7a0d4e27f1a7663a10851710f0285afef3467f7",
+      "https://snowtrace.io/address/0xf7a0d4e27f1a7663a10851710f0285afef3467f7",
       "https://avascan.info/blockchain/c/address/0xf7a0d4e27f1a7663a10851710f0285afef3467f7"
     ]
   },
@@ -643,7 +643,7 @@
     "type": "core",
     "description": "ELP farm for AVAX-ELK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x449ee12de33e45c5a5bacbbe0f9ddd276e0ef417",
+      "https://snowtrace.io/address/0x449ee12de33e45c5a5bacbbe0f9ddd276e0ef417",
       "https://avascan.info/blockchain/c/address/0x449ee12de33e45c5a5bacbbe0f9ddd276e0ef417"
     ]
   },
@@ -655,7 +655,7 @@
     "type": "core",
     "description": "ELP farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x18df163393c6da3285c2888461b8fd736272e245",
+      "https://snowtrace.io/address/0x18df163393c6da3285c2888461b8fd736272e245",
       "https://avascan.info/blockchain/c/address/0x18df163393c6da3285c2888461b8fd736272e245"
     ]
   },
@@ -667,7 +667,7 @@
     "type": "core",
     "description": "ELP farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6d76d0a8ad4f2325c6f4286dd3a40c1cd3b817de",
+      "https://snowtrace.io/address/0x6d76d0a8ad4f2325c6f4286dd3a40c1cd3b817de",
       "https://avascan.info/blockchain/c/address/0x6d76d0a8ad4f2325c6f4286dd3a40c1cd3b817de"
     ]
   },
@@ -679,7 +679,7 @@
     "type": "core",
     "description": "ELP farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaa22703af4a6575feb316f078bdc584a94fde108",
+      "https://snowtrace.io/address/0xaa22703af4a6575feb316f078bdc584a94fde108",
       "https://avascan.info/blockchain/c/address/0xaa22703af4a6575feb316f078bdc584a94fde108"
     ]
   },
@@ -691,7 +691,7 @@
     "type": "core",
     "description": "ELP farm for ELK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x07f11f5903af3bb24e27af0f794ef120726e76bb",
+      "https://snowtrace.io/address/0x07f11f5903af3bb24e27af0f794ef120726e76bb",
       "https://avascan.info/blockchain/c/address/0x07f11f5903af3bb24e27af0f794ef120726e76bb"
     ]
   },
@@ -703,7 +703,7 @@
     "type": "core",
     "description": "ELP farm for ELK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaca969fb39ff5d572a219838411f218de96615fb",
+      "https://snowtrace.io/address/0xaca969fb39ff5d572a219838411f218de96615fb",
       "https://avascan.info/blockchain/c/address/0xaca969fb39ff5d572a219838411f218de96615fb"
     ]
   },
@@ -715,7 +715,7 @@
     "type": "core",
     "description": "ELP farm for ELK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x20afdef84d1e87d9bfd8086f7269183e12c712e2",
+      "https://snowtrace.io/address/0x20afdef84d1e87d9bfd8086f7269183e12c712e2",
       "https://avascan.info/blockchain/c/address/0x20afdef84d1e87d9bfd8086f7269183e12c712e2"
     ]
   },
@@ -727,7 +727,7 @@
     "type": "core",
     "description": "ELP farm for ELK-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x50f91f231f8eeca4ff6e0d4f2dabe7d22228d34d",
+      "https://snowtrace.io/address/0x50f91f231f8eeca4ff6e0d4f2dabe7d22228d34d",
       "https://avascan.info/blockchain/c/address/0x50f91f231f8eeca4ff6e0d4f2dabe7d22228d34d"
     ]
   },
@@ -739,7 +739,7 @@
     "type": "core",
     "description": "ELP farm for ELK-DAIe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x23824a5df28fdb675299fa6b34a96e6cdae6eb2e",
+      "https://snowtrace.io/address/0x23824a5df28fdb675299fa6b34a96e6cdae6eb2e",
       "https://avascan.info/blockchain/c/address/0x23824a5df28fdb675299fa6b34a96e6cdae6eb2e"
     ]
   },
@@ -751,7 +751,7 @@
     "type": "core",
     "description": "ELP farm for ELK-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd661a38708e6544f2d32e302e6e893a97be7314c",
+      "https://snowtrace.io/address/0xd661a38708e6544f2d32e302e6e893a97be7314c",
       "https://avascan.info/blockchain/c/address/0xd661a38708e6544f2d32e302e6e893a97be7314c"
     ]
   },
@@ -763,7 +763,7 @@
     "type": "core",
     "description": "ELP farm for ELK-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaa21128578043c10c5c50bff1011879c5188ddb2",
+      "https://snowtrace.io/address/0xaa21128578043c10c5c50bff1011879c5188ddb2",
       "https://avascan.info/blockchain/c/address/0xaa21128578043c10c5c50bff1011879c5188ddb2"
     ]
   },
@@ -775,7 +775,7 @@
     "type": "core",
     "description": "ELP farm for ELK-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x882b1f5c8f5438e1c47ef464a6199c70f20cceda",
+      "https://snowtrace.io/address/0x882b1f5c8f5438e1c47ef464a6199c70f20cceda",
       "https://avascan.info/blockchain/c/address/0x882b1f5c8f5438e1c47ef464a6199c70f20cceda"
     ]
   },
@@ -787,7 +787,7 @@
     "type": "core",
     "description": "ELP farm for ELK-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xba78660bca43b5a692c632c2a02ff329701dcbf1",
+      "https://snowtrace.io/address/0xba78660bca43b5a692c632c2a02ff329701dcbf1",
       "https://avascan.info/blockchain/c/address/0xba78660bca43b5a692c632c2a02ff329701dcbf1"
     ]
   },
@@ -799,7 +799,7 @@
     "type": "core",
     "description": "ELP farm for ELK-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1a7d36d12e12abfa91e8da437bda4c86657163e5",
+      "https://snowtrace.io/address/0x1a7d36d12e12abfa91e8da437bda4c86657163e5",
       "https://avascan.info/blockchain/c/address/0x1a7d36d12e12abfa91e8da437bda4c86657163e5"
     ]
   },
@@ -811,7 +811,7 @@
     "type": "core",
     "description": "ELP farm for ELK-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc2387b6ab5b75aacd6a4a94e44f8402f1e8afdc2",
+      "https://snowtrace.io/address/0xc2387b6ab5b75aacd6a4a94e44f8402f1e8afdc2",
       "https://avascan.info/blockchain/c/address/0xc2387b6ab5b75aacd6a4a94e44f8402f1e8afdc2"
     ]
   },
@@ -823,7 +823,7 @@
     "type": "core",
     "description": "ELP farm for ELK-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x28cd1849acbe189805bbc06f2e192b81189ce3e5",
+      "https://snowtrace.io/address/0x28cd1849acbe189805bbc06f2e192b81189ce3e5",
       "https://avascan.info/blockchain/c/address/0x28cd1849acbe189805bbc06f2e192b81189ce3e5"
     ]
   },
@@ -835,7 +835,7 @@
     "type": "core",
     "description": "ELP farm for ELK-YAK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1498d43fc704dec72fd86b5f535da65603aa466a",
+      "https://snowtrace.io/address/0x1498d43fc704dec72fd86b5f535da65603aa466a",
       "https://avascan.info/blockchain/c/address/0x1498d43fc704dec72fd86b5f535da65603aa466a"
     ]
   },
@@ -847,7 +847,7 @@
     "type": "core",
     "description": "FROST farm for compounding DAIe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x67f8190a37aa1f3516713f849bdf3b7b9e3df3a0",
+      "https://snowtrace.io/address/0x67f8190a37aa1f3516713f849bdf3b7b9e3df3a0",
       "https://avascan.info/blockchain/c/address/0x67f8190a37aa1f3516713f849bdf3b7b9e3df3a0"
     ]
   },
@@ -859,7 +859,7 @@
     "type": "core",
     "description": "FROST farm for compounding JOE",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb6bf27b1b3e0ce30a91533f2fc251afbda53e187",
+      "https://snowtrace.io/address/0xb6bf27b1b3e0ce30a91533f2fc251afbda53e187",
       "https://avascan.info/blockchain/c/address/0xb6bf27b1b3e0ce30a91533f2fc251afbda53e187"
     ]
   },
@@ -871,7 +871,7 @@
     "type": "core",
     "description": "FROST farm for compounding PNG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8a39f38b783857fd128a8bc3354f981160d750a7",
+      "https://snowtrace.io/address/0x8a39f38b783857fd128a8bc3354f981160d750a7",
       "https://avascan.info/blockchain/c/address/0x8a39f38b783857fd128a8bc3354f981160d750a7"
     ]
   },
@@ -883,7 +883,7 @@
     "type": "core",
     "description": "FROST farm for compounding TUNDRA",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7873238a924c6f00be150b8cfdc3c233a8d5758b",
+      "https://snowtrace.io/address/0x7873238a924c6f00be150b8cfdc3c233a8d5758b",
       "https://avascan.info/blockchain/c/address/0x7873238a924c6f00be150b8cfdc3c233a8d5758b"
     ]
   },
@@ -895,7 +895,7 @@
     "type": "core",
     "description": "FROST farm for compounding USDTe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa13adb03619835e6e59ed0ed440be765017d8715",
+      "https://snowtrace.io/address/0xa13adb03619835e6e59ed0ed440be765017d8715",
       "https://avascan.info/blockchain/c/address/0xa13adb03619835e6e59ed0ed440be765017d8715"
     ]
   },
@@ -907,7 +907,7 @@
     "type": "core",
     "description": "FROST farm for compounding YAK",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x73d835325637faf11ae1838428510d9566e1a465",
+      "https://snowtrace.io/address/0x73d835325637faf11ae1838428510d9566e1a465",
       "https://avascan.info/blockchain/c/address/0x73d835325637faf11ae1838428510d9566e1a465"
     ]
   },
@@ -919,7 +919,7 @@
     "type": "core",
     "description": "GDL farm for DAI-ZDAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x57a6e0cef1e32bee5407bdcab57de10eeb383aa6",
+      "https://snowtrace.io/address/0x57a6e0cef1e32bee5407bdcab57de10eeb383aa6",
       "https://avascan.info/blockchain/c/address/0x57a6e0cef1e32bee5407bdcab57de10eeb383aa6"
     ]
   },
@@ -931,7 +931,7 @@
     "type": "core",
     "description": "GDL farm for DAIe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xecd3c537399d9dc65786a5accce94e48bd4988ff",
+      "https://snowtrace.io/address/0xecd3c537399d9dc65786a5accce94e48bd4988ff",
       "https://avascan.info/blockchain/c/address/0xecd3c537399d9dc65786a5accce94e48bd4988ff"
     ]
   },
@@ -943,7 +943,7 @@
     "type": "core",
     "description": "GDL farm for ETH-ZETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0caaa919feeb50029f99b288e43a73c66178c976",
+      "https://snowtrace.io/address/0x0caaa919feeb50029f99b288e43a73c66178c976",
       "https://avascan.info/blockchain/c/address/0x0caaa919feeb50029f99b288e43a73c66178c976"
     ]
   },
@@ -955,7 +955,7 @@
     "type": "core",
     "description": "GDL farm for compounding GDL",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb42cd0bea11ad9ec610f2bd5826463bb93396538",
+      "https://snowtrace.io/address/0xb42cd0bea11ad9ec610f2bd5826463bb93396538",
       "https://avascan.info/blockchain/c/address/0xb42cd0bea11ad9ec610f2bd5826463bb93396538"
     ]
   },
@@ -967,7 +967,7 @@
     "type": "core",
     "description": "GDL farm for USDT-ZUSDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9968f0c68b9d812c226f3d6eb3cd3c958979e1af",
+      "https://snowtrace.io/address/0x9968f0c68b9d812c226f3d6eb3cd3c958979e1af",
       "https://avascan.info/blockchain/c/address/0x9968f0c68b9d812c226f3d6eb3cd3c958979e1af"
     ]
   },
@@ -979,7 +979,7 @@
     "type": "core",
     "description": "GDL farm for USDTe-TSD LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x117a18e4f7514ba89e5a1bdf92e2202edaed90e1",
+      "https://snowtrace.io/address/0x117a18e4f7514ba89e5a1bdf92e2202edaed90e1",
       "https://avascan.info/blockchain/c/address/0x117a18e4f7514ba89e5a1bdf92e2202edaed90e1"
     ]
   },
@@ -991,7 +991,7 @@
     "type": "core",
     "description": "GDL farm for USDTe-USDCe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0f12dc66f750d95fe7612dc757d7f352521bb61d",
+      "https://snowtrace.io/address/0x0f12dc66f750d95fe7612dc757d7f352521bb61d",
       "https://avascan.info/blockchain/c/address/0x0f12dc66f750d95fe7612dc757d7f352521bb61d"
     ]
   },
@@ -1003,7 +1003,7 @@
     "type": "core",
     "description": "GDL farm for WBTC-ZBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8df0790e9b9f06add676b53136bd9734e4916d59",
+      "https://snowtrace.io/address/0x8df0790e9b9f06add676b53136bd9734e4916d59",
       "https://avascan.info/blockchain/c/address/0x8df0790e9b9f06add676b53136bd9734e4916d59"
     ]
   },
@@ -1015,7 +1015,7 @@
     "type": "core",
     "description": "GDL farm for mYAK-YAK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6dbf865f19cd0aaca9550bddd3b92f4f4e239468",
+      "https://snowtrace.io/address/0x6dbf865f19cd0aaca9550bddd3b92f4f4e239468",
       "https://avascan.info/blockchain/c/address/0x6dbf865f19cd0aaca9550bddd3b92f4f4e239468"
     ]
   },
@@ -1027,7 +1027,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x75cc908305b385ec1ff3646bf84718780f95f20b",
+      "https://snowtrace.io/address/0x75cc908305b385ec1ff3646bf84718780f95f20b",
       "https://avascan.info/blockchain/c/address/0x75cc908305b385ec1ff3646bf84718780f95f20b"
     ]
   },
@@ -1039,7 +1039,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb18bfb17859c6b90dc0e374fe763a8afce25d80c",
+      "https://snowtrace.io/address/0xb18bfb17859c6b90dc0e374fe763a8afce25d80c",
       "https://avascan.info/blockchain/c/address/0xb18bfb17859c6b90dc0e374fe763a8afce25d80c"
     ]
   },
@@ -1051,7 +1051,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-HUSKY LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xca400ebc7632a1a9346851a72fd41a7ef234077c",
+      "https://snowtrace.io/address/0xca400ebc7632a1a9346851a72fd41a7ef234077c",
       "https://avascan.info/blockchain/c/address/0xca400ebc7632a1a9346851a72fd41a7ef234077c"
     ]
   },
@@ -1063,7 +1063,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5ea465e27f76b084f864addc47f04df8012b376a",
+      "https://snowtrace.io/address/0x5ea465e27f76b084f864addc47f04df8012b376a",
       "https://avascan.info/blockchain/c/address/0x5ea465e27f76b084f864addc47f04df8012b376a"
     ]
   },
@@ -1075,7 +1075,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-LYD LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3335faf35c489a0872bb6e4adb274074b778c59a",
+      "https://snowtrace.io/address/0x3335faf35c489a0872bb6e4adb274074b778c59a",
       "https://avascan.info/blockchain/c/address/0x3335faf35c489a0872bb6e4adb274074b778c59a"
     ]
   },
@@ -1087,7 +1087,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-PEFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x92752c1d6912a12cd9cf71093b8812c29e8ef7f4",
+      "https://snowtrace.io/address/0x92752c1d6912a12cd9cf71093b8812c29e8ef7f4",
       "https://avascan.info/blockchain/c/address/0x92752c1d6912a12cd9cf71093b8812c29e8ef7f4"
     ]
   },
@@ -1099,7 +1099,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb5b9ce35e6b3d5f8c800f19be5d8a76d9901f6b5",
+      "https://snowtrace.io/address/0xb5b9ce35e6b3d5f8c800f19be5d8a76d9901f6b5",
       "https://avascan.info/blockchain/c/address/0xb5b9ce35e6b3d5f8c800f19be5d8a76d9901f6b5"
     ]
   },
@@ -1111,7 +1111,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x77c26728465277510c4e33820a4d3b686f44ab7e",
+      "https://snowtrace.io/address/0x77c26728465277510c4e33820a4d3b686f44ab7e",
       "https://avascan.info/blockchain/c/address/0x77c26728465277510c4e33820a4d3b686f44ab7e"
     ]
   },
@@ -1123,7 +1123,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3d964716c98e732f84542fe38bdc3d21d1c7a9b1",
+      "https://snowtrace.io/address/0x3d964716c98e732f84542fe38bdc3d21d1c7a9b1",
       "https://avascan.info/blockchain/c/address/0x3d964716c98e732f84542fe38bdc3d21d1c7a9b1"
     ]
   },
@@ -1135,7 +1135,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x85d6f430f30b24f5e933cb3f5e52487def8f4e75",
+      "https://snowtrace.io/address/0x85d6f430f30b24f5e933cb3f5e52487def8f4e75",
       "https://avascan.info/blockchain/c/address/0x85d6f430f30b24f5e933cb3f5e52487def8f4e75"
     ]
   },
@@ -1147,7 +1147,7 @@
     "type": "core",
     "description": "JLP farm for AVAX-XAVA LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd3d10b328c6cee9fd599b11ea1272fe829409bba",
+      "https://snowtrace.io/address/0xd3d10b328c6cee9fd599b11ea1272fe829409bba",
       "https://avascan.info/blockchain/c/address/0xd3d10b328c6cee9fd599b11ea1272fe829409bba"
     ]
   },
@@ -1159,7 +1159,7 @@
     "type": "core",
     "description": "JLP farm for DAI-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf6a7b70641bc02ebe9e57f347ac8aa7197872e94",
+      "https://snowtrace.io/address/0xf6a7b70641bc02ebe9e57f347ac8aa7197872e94",
       "https://avascan.info/blockchain/c/address/0xf6a7b70641bc02ebe9e57f347ac8aa7197872e94"
     ]
   },
@@ -1171,7 +1171,7 @@
     "type": "core",
     "description": "JLP farm for DAIe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x698bceee246934fbffdbe222cc4444ae7585c3cb",
+      "https://snowtrace.io/address/0x698bceee246934fbffdbe222cc4444ae7585c3cb",
       "https://avascan.info/blockchain/c/address/0x698bceee246934fbffdbe222cc4444ae7585c3cb"
     ]
   },
@@ -1183,7 +1183,7 @@
     "type": "core",
     "description": "JLP farm for DAIe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x90148b6a79253c67131dddf58ecb39b11663e40c",
+      "https://snowtrace.io/address/0x90148b6a79253c67131dddf58ecb39b11663e40c",
       "https://avascan.info/blockchain/c/address/0x90148b6a79253c67131dddf58ecb39b11663e40c"
     ]
   },
@@ -1195,7 +1195,7 @@
     "type": "core",
     "description": "JLP farm for ELE-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe8917e088ffaf180b061f6eaac061bcf20f0ab70",
+      "https://snowtrace.io/address/0xe8917e088ffaf180b061f6eaac061bcf20f0ab70",
       "https://avascan.info/blockchain/c/address/0xe8917e088ffaf180b061f6eaac061bcf20f0ab70"
     ]
   },
@@ -1207,7 +1207,7 @@
     "type": "core",
     "description": "JLP farm for ETH-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe0a322b728275aced0323c9264b41184a75762f2",
+      "https://snowtrace.io/address/0xe0a322b728275aced0323c9264b41184a75762f2",
       "https://avascan.info/blockchain/c/address/0xe0a322b728275aced0323c9264b41184a75762f2"
     ]
   },
@@ -1219,7 +1219,7 @@
     "type": "core",
     "description": "JLP farm for FRAX-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6da2cd9d221a79769a72d78525437bb78602c57f",
+      "https://snowtrace.io/address/0x6da2cd9d221a79769a72d78525437bb78602c57f",
       "https://avascan.info/blockchain/c/address/0x6da2cd9d221a79769a72d78525437bb78602c57f"
     ]
   },
@@ -1231,7 +1231,7 @@
     "type": "core",
     "description": "JLP farm for JOE-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xed8c2af5c9f7a0fa5aaa0d8f8e78ddca28eef3d6",
+      "https://snowtrace.io/address/0xed8c2af5c9f7a0fa5aaa0d8f8e78ddca28eef3d6",
       "https://avascan.info/blockchain/c/address/0xed8c2af5c9f7a0fa5aaa0d8f8e78ddca28eef3d6"
     ]
   },
@@ -1243,7 +1243,7 @@
     "type": "core",
     "description": "JLP farm for JOE-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1026733bbc59edb627bf194b49f913a7a466466f",
+      "https://snowtrace.io/address/0x1026733bbc59edb627bf194b49f913a7a466466f",
       "https://avascan.info/blockchain/c/address/0x1026733bbc59edb627bf194b49f913a7a466466f"
     ]
   },
@@ -1255,7 +1255,7 @@
     "type": "core",
     "description": "JLP farm for JOE-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x551e9e18b2d292c3189f47ac129a5179db6ebc30",
+      "https://snowtrace.io/address/0x551e9e18b2d292c3189f47ac129a5179db6ebc30",
       "https://avascan.info/blockchain/c/address/0x551e9e18b2d292c3189f47ac129a5179db6ebc30"
     ]
   },
@@ -1267,7 +1267,7 @@
     "type": "core",
     "description": "JLP farm for JOE-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x964a0c4f0c03a3d307df4266e3a73a33fc804dbf",
+      "https://snowtrace.io/address/0x964a0c4f0c03a3d307df4266e3a73a33fc804dbf",
       "https://avascan.info/blockchain/c/address/0x964a0c4f0c03a3d307df4266e3a73a33fc804dbf"
     ]
   },
@@ -1279,7 +1279,7 @@
     "type": "core",
     "description": "JLP farm for JOE-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3b2464afcdccaca302357736df4b1d552e239fee",
+      "https://snowtrace.io/address/0x3b2464afcdccaca302357736df4b1d552e239fee",
       "https://avascan.info/blockchain/c/address/0x3b2464afcdccaca302357736df4b1d552e239fee"
     ]
   },
@@ -1291,7 +1291,7 @@
     "type": "core",
     "description": "JLP farm for LINK-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa4d9ae5f2338e561182f030751654c2f4c00de8f",
+      "https://snowtrace.io/address/0xa4d9ae5f2338e561182f030751654c2f4c00de8f",
       "https://avascan.info/blockchain/c/address/0xa4d9ae5f2338e561182f030751654c2f4c00de8f"
     ]
   },
@@ -1303,7 +1303,7 @@
     "type": "core",
     "description": "JLP farm for LINKe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1227a55a86aca0331e450ba6a3750054da35347d",
+      "https://snowtrace.io/address/0x1227a55a86aca0331e450ba6a3750054da35347d",
       "https://avascan.info/blockchain/c/address/0x1227a55a86aca0331e450ba6a3750054da35347d"
     ]
   },
@@ -1315,7 +1315,7 @@
     "type": "core",
     "description": "JLP farm for LINKe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x972ccef781feb87450d52d929685b162e9d305c4",
+      "https://snowtrace.io/address/0x972ccef781feb87450d52d929685b162e9d305c4",
       "https://avascan.info/blockchain/c/address/0x972ccef781feb87450d52d929685b162e9d305c4"
     ]
   },
@@ -1327,7 +1327,7 @@
     "type": "core",
     "description": "JLP farm for MIM-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x11303d1552c95f96cad65a3c0797f20d043e1ab5",
+      "https://snowtrace.io/address/0x11303d1552c95f96cad65a3c0797f20d043e1ab5",
       "https://avascan.info/blockchain/c/address/0x11303d1552c95f96cad65a3c0797f20d043e1ab5"
     ]
   },
@@ -1339,7 +1339,7 @@
     "type": "core",
     "description": "JLP farm for QI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1feb96ef9b166859280b6992d4d6c4cdc5b694f6",
+      "https://snowtrace.io/address/0x1feb96ef9b166859280b6992d4d6c4cdc5b694f6",
       "https://avascan.info/blockchain/c/address/0x1feb96ef9b166859280b6992d4d6c4cdc5b694f6"
     ]
   },
@@ -1351,7 +1351,7 @@
     "type": "core",
     "description": "JLP farm for SHERPA-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6d0b40b7b1e5f68132e7fad3a4a6bc06f165f560",
+      "https://snowtrace.io/address/0x6d0b40b7b1e5f68132e7fad3a4a6bc06f165f560",
       "https://avascan.info/blockchain/c/address/0x6d0b40b7b1e5f68132e7fad3a4a6bc06f165f560"
     ]
   },
@@ -1363,7 +1363,7 @@
     "type": "core",
     "description": "JLP farm for SPELL-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x46ce405ee945b2d2cc494c62105d8284fb04b8ba",
+      "https://snowtrace.io/address/0x46ce405ee945b2d2cc494c62105d8284fb04b8ba",
       "https://avascan.info/blockchain/c/address/0x46ce405ee945b2d2cc494c62105d8284fb04b8ba"
     ]
   },
@@ -1375,7 +1375,7 @@
     "type": "core",
     "description": "JLP farm for SYN-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x19d6c1acd4dda69b54bbe5da8c45d8261a0e47fb",
+      "https://snowtrace.io/address/0x19d6c1acd4dda69b54bbe5da8c45d8261a0e47fb",
       "https://avascan.info/blockchain/c/address/0x19d6c1acd4dda69b54bbe5da8c45d8261a0e47fb"
     ]
   },
@@ -1387,7 +1387,7 @@
     "type": "core",
     "description": "JLP farm for TIME-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x048db6c50ffd46df3bbd8332bb65c062f8d961a8",
+      "https://snowtrace.io/address/0x048db6c50ffd46df3bbd8332bb65c062f8d961a8",
       "https://avascan.info/blockchain/c/address/0x048db6c50ffd46df3bbd8332bb65c062f8d961a8"
     ]
   },
@@ -1399,7 +1399,7 @@
     "type": "core",
     "description": "JLP farm for USDCe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa1801f4ffd40b192a13a54614e66d3625d5c422e",
+      "https://snowtrace.io/address/0xa1801f4ffd40b192a13a54614e66d3625d5c422e",
       "https://avascan.info/blockchain/c/address/0xa1801f4ffd40b192a13a54614e66d3625d5c422e"
     ]
   },
@@ -1411,7 +1411,7 @@
     "type": "core",
     "description": "JLP farm for USDCe-DAIe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7257f259c17226c5b09048308403757a6680f2c1",
+      "https://snowtrace.io/address/0x7257f259c17226c5b09048308403757a6680f2c1",
       "https://avascan.info/blockchain/c/address/0x7257f259c17226c5b09048308403757a6680f2c1"
     ]
   },
@@ -1423,7 +1423,7 @@
     "type": "core",
     "description": "JLP farm for USDTe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdd65bb46a7c4a9ccb8d3dd7caa40d75e0622e445",
+      "https://snowtrace.io/address/0xdd65bb46a7c4a9ccb8d3dd7caa40d75e0622e445",
       "https://avascan.info/blockchain/c/address/0xdd65bb46a7c4a9ccb8d3dd7caa40d75e0622e445"
     ]
   },
@@ -1435,7 +1435,7 @@
     "type": "core",
     "description": "JLP farm for USDTe-USDCe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0b3f8efa73b40ab006b99867d9abfc76dcf699c4",
+      "https://snowtrace.io/address/0x0b3f8efa73b40ab006b99867d9abfc76dcf699c4",
       "https://avascan.info/blockchain/c/address/0x0b3f8efa73b40ab006b99867d9abfc76dcf699c4"
     ]
   },
@@ -1447,7 +1447,7 @@
     "type": "core",
     "description": "JLP farm for WBTC-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd3c3d0f3c745295c3cf727e3da0c33f6296c16b1",
+      "https://snowtrace.io/address/0xd3c3d0f3c745295c3cf727e3da0c33f6296c16b1",
       "https://avascan.info/blockchain/c/address/0xd3c3d0f3c745295c3cf727e3da0c33f6296c16b1"
     ]
   },
@@ -1459,7 +1459,7 @@
     "type": "core",
     "description": "JLP farm for WBTCe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf3b07e79e1f18315006642e9e5c1484d2c97a9e4",
+      "https://snowtrace.io/address/0xf3b07e79e1f18315006642e9e5c1484d2c97a9e4",
       "https://avascan.info/blockchain/c/address/0xf3b07e79e1f18315006642e9e5c1484d2c97a9e4"
     ]
   },
@@ -1471,7 +1471,7 @@
     "type": "core",
     "description": "JLP farm for WBTCe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xcb3257195a3cec8f97d2375b7aa4939ce3e125e9",
+      "https://snowtrace.io/address/0xcb3257195a3cec8f97d2375b7aa4939ce3e125e9",
       "https://avascan.info/blockchain/c/address/0xcb3257195a3cec8f97d2375b7aa4939ce3e125e9"
     ]
   },
@@ -1483,7 +1483,7 @@
     "type": "core",
     "description": "JLP farm for WET-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1154831d66afe2e825c0b400a0780b9756cc3240",
+      "https://snowtrace.io/address/0x1154831d66afe2e825c0b400a0780b9756cc3240",
       "https://avascan.info/blockchain/c/address/0x1154831d66afe2e825c0b400a0780b9756cc3240"
     ]
   },
@@ -1495,7 +1495,7 @@
     "type": "core",
     "description": "JLP farm for WETHe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x45af056a757d6649c24d74c2e4fe449682f6a2db",
+      "https://snowtrace.io/address/0x45af056a757d6649c24d74c2e4fe449682f6a2db",
       "https://avascan.info/blockchain/c/address/0x45af056a757d6649c24d74c2e4fe449682f6a2db"
     ]
   },
@@ -1507,7 +1507,7 @@
     "type": "core",
     "description": "JLP farm for WETHe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x16aeb10777f1315fc28084fe35a45f377c161cd3",
+      "https://snowtrace.io/address/0x16aeb10777f1315fc28084fe35a45f377c161cd3",
       "https://avascan.info/blockchain/c/address/0x16aeb10777f1315fc28084fe35a45f377c161cd3"
     ]
   },
@@ -1519,7 +1519,7 @@
     "type": "core",
     "description": "JLP farm for YAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x468eba06c845205fb79098ef3b95c0b319dc0541",
+      "https://snowtrace.io/address/0x468eba06c845205fb79098ef3b95c0b319dc0541",
       "https://avascan.info/blockchain/c/address/0x468eba06c845205fb79098ef3b95c0b319dc0541"
     ]
   },
@@ -1531,7 +1531,7 @@
     "type": "core",
     "description": "JLP farm for ZABU-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x68e7dd061b068ea476e979215e3c08a235bd0cee",
+      "https://snowtrace.io/address/0x68e7dd061b068ea476e979215e3c08a235bd0cee",
       "https://avascan.info/blockchain/c/address/0x68e7dd061b068ea476e979215e3c08a235bd0cee"
     ]
   },
@@ -1543,7 +1543,7 @@
     "type": "core",
     "description": "JLP farm for ZABU-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0280988155edb58210fe30be5d429c0f1b91bce6",
+      "https://snowtrace.io/address/0x0280988155edb58210fe30be5d429c0f1b91bce6",
       "https://avascan.info/blockchain/c/address/0x0280988155edb58210fe30be5d429c0f1b91bce6"
     ]
   },
@@ -1555,7 +1555,7 @@
     "type": "core",
     "description": "JLP farm for mYAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x69d8ebe4a431d51ef6720b7e4aed213615d2e614",
+      "https://snowtrace.io/address/0x69d8ebe4a431d51ef6720b7e4aed213615d2e614",
       "https://avascan.info/blockchain/c/address/0x69d8ebe4a431d51ef6720b7e4aed213615d2e614"
     ]
   },
@@ -1567,7 +1567,7 @@
     "type": "core",
     "description": "JOE farm for compounding JOE",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x99d6acaca55ffca5fe47755d17865d394e59c891",
+      "https://snowtrace.io/address/0x99d6acaca55ffca5fe47755d17865d394e59c891",
       "https://avascan.info/blockchain/c/address/0x99d6acaca55ffca5fe47755d17865d394e59c891"
     ]
   },
@@ -1579,7 +1579,7 @@
     "type": "core",
     "description": "LYDIA farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2ee33e53ebd75222c7c62f1e9feb0bc9766136ba",
+      "https://snowtrace.io/address/0x2ee33e53ebd75222c7c62f1e9feb0bc9766136ba",
       "https://avascan.info/blockchain/c/address/0x2ee33e53ebd75222c7c62f1e9feb0bc9766136ba"
     ]
   },
@@ -1591,7 +1591,7 @@
     "type": "core",
     "description": "LYDIA farm for AVAX-SUSHI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf752325d33f748115660b8661ab7de10cfd1997c",
+      "https://snowtrace.io/address/0xf752325d33f748115660b8661ab7de10cfd1997c",
       "https://avascan.info/blockchain/c/address/0xf752325d33f748115660b8661ab7de10cfd1997c"
     ]
   },
@@ -1603,7 +1603,7 @@
     "type": "core",
     "description": "LYDIA farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7346502437c9f09ab040855f756edea2a2ac0912",
+      "https://snowtrace.io/address/0x7346502437c9f09ab040855f756edea2a2ac0912",
       "https://avascan.info/blockchain/c/address/0x7346502437c9f09ab040855f756edea2a2ac0912"
     ]
   },
@@ -1615,7 +1615,7 @@
     "type": "core",
     "description": "LYDIA farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x197e2ae97a783b9a7958eafd01e2467b875989d7",
+      "https://snowtrace.io/address/0x197e2ae97a783b9a7958eafd01e2467b875989d7",
       "https://avascan.info/blockchain/c/address/0x197e2ae97a783b9a7958eafd01e2467b875989d7"
     ]
   },
@@ -1627,7 +1627,7 @@
     "type": "core",
     "description": "LYDIA farm for DAIe-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1933133cfab7fd8908e776e63095ac58c0faeae3",
+      "https://snowtrace.io/address/0x1933133cfab7fd8908e776e63095ac58c0faeae3",
       "https://avascan.info/blockchain/c/address/0x1933133cfab7fd8908e776e63095ac58c0faeae3"
     ]
   },
@@ -1639,7 +1639,7 @@
     "type": "core",
     "description": "LYDIA farm for LINKe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc8410344fda4f4a348492a19b099b389494ed668",
+      "https://snowtrace.io/address/0xc8410344fda4f4a348492a19b099b389494ed668",
       "https://avascan.info/blockchain/c/address/0xc8410344fda4f4a348492a19b099b389494ed668"
     ]
   },
@@ -1651,7 +1651,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xffbe3f2b1ff3f595e3059cca8a7fcd3eb4d71949",
+      "https://snowtrace.io/address/0xffbe3f2b1ff3f595e3059cca8a7fcd3eb4d71949",
       "https://avascan.info/blockchain/c/address/0xffbe3f2b1ff3f595e3059cca8a7fcd3eb4d71949"
     ]
   },
@@ -1663,7 +1663,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-DAIe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb9d554fee84fa97feee3525a162602860ae554c5",
+      "https://snowtrace.io/address/0xb9d554fee84fa97feee3525a162602860ae554c5",
       "https://avascan.info/blockchain/c/address/0xb9d554fee84fa97feee3525a162602860ae554c5"
     ]
   },
@@ -1675,7 +1675,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7a43d565837274ea2f6e6d95f4020871669c13c9",
+      "https://snowtrace.io/address/0x7a43d565837274ea2f6e6d95f4020871669c13c9",
       "https://avascan.info/blockchain/c/address/0x7a43d565837274ea2f6e6d95f4020871669c13c9"
     ]
   },
@@ -1687,7 +1687,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x104a9f8c3a1f3bf0814105e1fd457cd7775979ce",
+      "https://snowtrace.io/address/0x104a9f8c3a1f3bf0814105e1fd457cd7775979ce",
       "https://avascan.info/blockchain/c/address/0x104a9f8c3a1f3bf0814105e1fd457cd7775979ce"
     ]
   },
@@ -1699,7 +1699,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf947758148e056cd8096efd07f536b59f3247206",
+      "https://snowtrace.io/address/0xf947758148e056cd8096efd07f536b59f3247206",
       "https://avascan.info/blockchain/c/address/0xf947758148e056cd8096efd07f536b59f3247206"
     ]
   },
@@ -1711,7 +1711,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x069e889d729d4d96dae10c86a4d1f629ad81adef",
+      "https://snowtrace.io/address/0x069e889d729d4d96dae10c86a4d1f629ad81adef",
       "https://avascan.info/blockchain/c/address/0x069e889d729d4d96dae10c86a4d1f629ad81adef"
     ]
   },
@@ -1723,7 +1723,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4934d7c4f22829432be73bb29e7882b39f5e5c31",
+      "https://snowtrace.io/address/0x4934d7c4f22829432be73bb29e7882b39f5e5c31",
       "https://avascan.info/blockchain/c/address/0x4934d7c4f22829432be73bb29e7882b39f5e5c31"
     ]
   },
@@ -1735,7 +1735,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-WETHe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8ffeac711b0f7dff69228eb40f33034b5fb822a2",
+      "https://snowtrace.io/address/0x8ffeac711b0f7dff69228eb40f33034b5fb822a2",
       "https://avascan.info/blockchain/c/address/0x8ffeac711b0f7dff69228eb40f33034b5fb822a2"
     ]
   },
@@ -1747,7 +1747,7 @@
     "type": "core",
     "description": "LYDIA farm for LYD-XAVA LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x998db5870f83fc6a1908125e3d7b85d58c9fa806",
+      "https://snowtrace.io/address/0x998db5870f83fc6a1908125e3d7b85d58c9fa806",
       "https://avascan.info/blockchain/c/address/0x998db5870f83fc6a1908125e3d7b85d58c9fa806"
     ]
   },
@@ -1759,7 +1759,7 @@
     "type": "core",
     "description": "LYDIA farm for QI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x87cb748dcc4e22c0e6928b0be738d958fee4f304",
+      "https://snowtrace.io/address/0x87cb748dcc4e22c0e6928b0be738d958fee4f304",
       "https://avascan.info/blockchain/c/address/0x87cb748dcc4e22c0e6928b0be738d958fee4f304"
     ]
   },
@@ -1771,7 +1771,7 @@
     "type": "core",
     "description": "LYDIA farm for USDTe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x622be93c63fa148ec78fdb508ac1af1ba8bc0dd4",
+      "https://snowtrace.io/address/0x622be93c63fa148ec78fdb508ac1af1ba8bc0dd4",
       "https://avascan.info/blockchain/c/address/0x622be93c63fa148ec78fdb508ac1af1ba8bc0dd4"
     ]
   },
@@ -1783,7 +1783,7 @@
     "type": "core",
     "description": "LYDIA farm for WBTCe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x481480fceeca146743d75bfda581946efbc74261",
+      "https://snowtrace.io/address/0x481480fceeca146743d75bfda581946efbc74261",
       "https://avascan.info/blockchain/c/address/0x481480fceeca146743d75bfda581946efbc74261"
     ]
   },
@@ -1795,7 +1795,7 @@
     "type": "core",
     "description": "LYDIA farm for WETHe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc6ebfb1199fca2841ac8a30c5ac2d28ced2ee204",
+      "https://snowtrace.io/address/0xc6ebfb1199fca2841ac8a30c5ac2d28ced2ee204",
       "https://avascan.info/blockchain/c/address/0xc6ebfb1199fca2841ac8a30c5ac2d28ced2ee204"
     ]
   },
@@ -1807,7 +1807,7 @@
     "type": "core",
     "description": "LYDIA farm for YAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf32309a6c21c1c27b0a6b87e607b9862d67be21f",
+      "https://snowtrace.io/address/0xf32309a6c21c1c27b0a6b87e607b9862d67be21f",
       "https://avascan.info/blockchain/c/address/0xf32309a6c21c1c27b0a6b87e607b9862d67be21f"
     ]
   },
@@ -1819,7 +1819,7 @@
     "type": "core",
     "description": "OLIVE farm for compounding OLIVE",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4dd36b27e038e5c479d8bec440c8f4ee89b6df5d",
+      "https://snowtrace.io/address/0x4dd36b27e038e5c479d8bec440c8f4ee89b6df5d",
       "https://avascan.info/blockchain/c/address/0x4dd36b27e038e5c479d8bec440c8f4ee89b6df5d"
     ]
   },
@@ -1831,7 +1831,7 @@
     "type": "core",
     "description": "Olive farm for AVAX-ELK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xded4e24c158b973d4cd309b19295954dd0ad5a23",
+      "https://snowtrace.io/address/0xded4e24c158b973d4cd309b19295954dd0ad5a23",
       "https://avascan.info/blockchain/c/address/0xded4e24c158b973d4cd309b19295954dd0ad5a23"
     ]
   },
@@ -1843,7 +1843,7 @@
     "type": "core",
     "description": "Olive farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa019f49464fcd206d080060cbbcb1a089441a732",
+      "https://snowtrace.io/address/0xa019f49464fcd206d080060cbbcb1a089441a732",
       "https://avascan.info/blockchain/c/address/0xa019f49464fcd206d080060cbbcb1a089441a732"
     ]
   },
@@ -1855,7 +1855,7 @@
     "type": "core",
     "description": "Olive farm for AVAX-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4cacece41645ae3a78655cdc33320bed00f72437",
+      "https://snowtrace.io/address/0x4cacece41645ae3a78655cdc33320bed00f72437",
       "https://avascan.info/blockchain/c/address/0x4cacece41645ae3a78655cdc33320bed00f72437"
     ]
   },
@@ -1867,7 +1867,7 @@
     "type": "core",
     "description": "Olive farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x212df67bf1243ee57686883c9222637136bb65e4",
+      "https://snowtrace.io/address/0x212df67bf1243ee57686883c9222637136bb65e4",
       "https://avascan.info/blockchain/c/address/0x212df67bf1243ee57686883c9222637136bb65e4"
     ]
   },
@@ -1879,7 +1879,7 @@
     "type": "core",
     "description": "Olive farm for DAI-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc82ad2eab7ee0b9226ae884255ca9c1cb33d9e2c",
+      "https://snowtrace.io/address/0xc82ad2eab7ee0b9226ae884255ca9c1cb33d9e2c",
       "https://avascan.info/blockchain/c/address/0xc82ad2eab7ee0b9226ae884255ca9c1cb33d9e2c"
     ]
   },
@@ -1891,7 +1891,7 @@
     "type": "core",
     "description": "Olive farm for OLIVE-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfdffdf6dc4fb30bede8af0f78d42c5468f37324b",
+      "https://snowtrace.io/address/0xfdffdf6dc4fb30bede8af0f78d42c5468f37324b",
       "https://avascan.info/blockchain/c/address/0xfdffdf6dc4fb30bede8af0f78d42c5468f37324b"
     ]
   },
@@ -1903,7 +1903,7 @@
     "type": "core",
     "description": "Olive farm for OLIVE-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x89a806347b0814a265dc17afc343866b2214dd0f",
+      "https://snowtrace.io/address/0x89a806347b0814a265dc17afc343866b2214dd0f",
       "https://avascan.info/blockchain/c/address/0x89a806347b0814a265dc17afc343866b2214dd0f"
     ]
   },
@@ -1915,7 +1915,7 @@
     "type": "core",
     "description": "Olive farm for PNG-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xec2258cc4b75ad0a013c7346c07f7470aea7f0e4",
+      "https://snowtrace.io/address/0xec2258cc4b75ad0a013c7346c07f7470aea7f0e4",
       "https://avascan.info/blockchain/c/address/0xec2258cc4b75ad0a013c7346c07f7470aea7f0e4"
     ]
   },
@@ -1927,7 +1927,7 @@
     "type": "core",
     "description": "Olive farm for SUSHI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3a8d3fbab8b87473b9b2d78393200b099fa98497",
+      "https://snowtrace.io/address/0x3a8d3fbab8b87473b9b2d78393200b099fa98497",
       "https://avascan.info/blockchain/c/address/0x3a8d3fbab8b87473b9b2d78393200b099fa98497"
     ]
   },
@@ -1939,7 +1939,7 @@
     "type": "core",
     "description": "Olive farm for WBTC-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9c36eca9309f0ceb5818da889e47d3c3e2ba9f32",
+      "https://snowtrace.io/address/0x9c36eca9309f0ceb5818da889e47d3c3e2ba9f32",
       "https://avascan.info/blockchain/c/address/0x9c36eca9309f0ceb5818da889e47d3c3e2ba9f32"
     ]
   },
@@ -1951,7 +1951,7 @@
     "type": "core",
     "description": "Olive farm for mYAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x75912bf4454e7f7ea21b83bd1313974b69d8c63a",
+      "https://snowtrace.io/address/0x75912bf4454e7f7ea21b83bd1313974b69d8c63a",
       "https://avascan.info/blockchain/c/address/0x75912bf4454e7f7ea21b83bd1313974b69d8c63a"
     ]
   },
@@ -1963,7 +1963,7 @@
     "type": "core",
     "description": "PEFI_PGL farm for ETH-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8d325d788140c391fcb55a45e19bb4c66ef87529",
+      "https://snowtrace.io/address/0x8d325d788140c391fcb55a45e19bb4c66ef87529",
       "https://avascan.info/blockchain/c/address/0x8d325d788140c391fcb55a45e19bb4c66ef87529"
     ]
   },
@@ -1975,7 +1975,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-AAVE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x09ad8bafb4da3951ff8d4eebd91c654bceab053c",
+      "https://snowtrace.io/address/0x09ad8bafb4da3951ff8d4eebd91c654bceab053c",
       "https://avascan.info/blockchain/c/address/0x09ad8bafb4da3951ff8d4eebd91c654bceab053c"
     ]
   },
@@ -1987,7 +1987,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-AAVE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbab74ca880e918440ad5a8b9ccece56cce5cda31",
+      "https://snowtrace.io/address/0xbab74ca880e918440ad5a8b9ccece56cce5cda31",
       "https://avascan.info/blockchain/c/address/0xbab74ca880e918440ad5a8b9ccece56cce5cda31"
     ]
   },
@@ -1999,7 +1999,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xebbe895fa78d8cebcc44a68dc95689f53b66c9a7",
+      "https://snowtrace.io/address/0xebbe895fa78d8cebcc44a68dc95689f53b66c9a7",
       "https://avascan.info/blockchain/c/address/0xebbe895fa78d8cebcc44a68dc95689f53b66c9a7"
     ]
   },
@@ -2011,7 +2011,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb373a54f7f773a99febe49f2c5db11756574f0ce",
+      "https://snowtrace.io/address/0xb373a54f7f773a99febe49f2c5db11756574f0ce",
       "https://avascan.info/blockchain/c/address/0xb373a54f7f773a99febe49f2c5db11756574f0ce"
     ]
   },
@@ -2023,7 +2023,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x241f66d7ae5053b63367bb083ba7d6c364ff4987",
+      "https://snowtrace.io/address/0x241f66d7ae5053b63367bb083ba7d6c364ff4987",
       "https://avascan.info/blockchain/c/address/0x241f66d7ae5053b63367bb083ba7d6c364ff4987"
     ]
   },
@@ -2035,7 +2035,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa7d7cdc5671858aef49827a7a06a0e0880f8eebf",
+      "https://snowtrace.io/address/0xa7d7cdc5671858aef49827a7a06a0e0880f8eebf",
       "https://avascan.info/blockchain/c/address/0xa7d7cdc5671858aef49827a7a06a0e0880f8eebf"
     ]
   },
@@ -2047,7 +2047,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x06404fc9c69f8333dc24d4c856e2c8db7983eb8a",
+      "https://snowtrace.io/address/0x06404fc9c69f8333dc24d4c856e2c8db7983eb8a",
       "https://avascan.info/blockchain/c/address/0x06404fc9c69f8333dc24d4c856e2c8db7983eb8a"
     ]
   },
@@ -2059,7 +2059,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x02fe99babb22da03b19d4696169b7e92f35445b9",
+      "https://snowtrace.io/address/0x02fe99babb22da03b19d4696169b7e92f35445b9",
       "https://avascan.info/blockchain/c/address/0x02fe99babb22da03b19d4696169b7e92f35445b9"
     ]
   },
@@ -2071,7 +2071,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0bc2fb2d9ba486cbf9e6192f982023f72e80f96f",
+      "https://snowtrace.io/address/0x0bc2fb2d9ba486cbf9e6192f982023f72e80f96f",
       "https://avascan.info/blockchain/c/address/0x0bc2fb2d9ba486cbf9e6192f982023f72e80f96f"
     ]
   },
@@ -2083,7 +2083,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-PEFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x579cf87201c82b21ba9ae29678b812e07fccf14c",
+      "https://snowtrace.io/address/0x579cf87201c82b21ba9ae29678b812e07fccf14c",
       "https://avascan.info/blockchain/c/address/0x579cf87201c82b21ba9ae29678b812e07fccf14c"
     ]
   },
@@ -2095,7 +2095,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6eda40218604b9abe4dc40d68a23a86f1f50b66c",
+      "https://snowtrace.io/address/0x6eda40218604b9abe4dc40d68a23a86f1f50b66c",
       "https://avascan.info/blockchain/c/address/0x6eda40218604b9abe4dc40d68a23a86f1f50b66c"
     ]
   },
@@ -2107,7 +2107,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdf8cd9449babbf8c7687bbdb69d09eb413b78018",
+      "https://snowtrace.io/address/0xdf8cd9449babbf8c7687bbdb69d09eb413b78018",
       "https://avascan.info/blockchain/c/address/0xdf8cd9449babbf8c7687bbdb69d09eb413b78018"
     ]
   },
@@ -2119,7 +2119,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa544b965c2a05b97c44f3126cec916332afb3175",
+      "https://snowtrace.io/address/0xa544b965c2a05b97c44f3126cec916332afb3175",
       "https://avascan.info/blockchain/c/address/0xa544b965c2a05b97c44f3126cec916332afb3175"
     ]
   },
@@ -2131,7 +2131,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc9cd088fd5c17d5cbfd1ff331fa6a48f2f5d9cb1",
+      "https://snowtrace.io/address/0xc9cd088fd5c17d5cbfd1ff331fa6a48f2f5d9cb1",
       "https://avascan.info/blockchain/c/address/0xc9cd088fd5c17d5cbfd1ff331fa6a48f2f5d9cb1"
     ]
   },
@@ -2143,7 +2143,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3b23e8a535b2a9e4c73f617c1c5a36299b3c57b2",
+      "https://snowtrace.io/address/0x3b23e8a535b2a9e4c73f617c1c5a36299b3c57b2",
       "https://avascan.info/blockchain/c/address/0x3b23e8a535b2a9e4c73f617c1c5a36299b3c57b2"
     ]
   },
@@ -2155,7 +2155,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SPORE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x81514f9533753137e9f8842fe4bdefffa3e3dced",
+      "https://snowtrace.io/address/0x81514f9533753137e9f8842fe4bdefffa3e3dced",
       "https://avascan.info/blockchain/c/address/0x81514f9533753137e9f8842fe4bdefffa3e3dced"
     ]
   },
@@ -2167,7 +2167,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SPORE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7be1a6637d753b16e5ff4e00f917bb921617d805",
+      "https://snowtrace.io/address/0x7be1a6637d753b16e5ff4e00f917bb921617d805",
       "https://avascan.info/blockchain/c/address/0x7be1a6637d753b16e5ff4e00f917bb921617d805"
     ]
   },
@@ -2179,7 +2179,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SUSHI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xcdc094b37015569178fa6920492228af811c4db9",
+      "https://snowtrace.io/address/0xcdc094b37015569178fa6920492228af811c4db9",
       "https://avascan.info/blockchain/c/address/0xcdc094b37015569178fa6920492228af811c4db9"
     ]
   },
@@ -2191,7 +2191,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-SUSHI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x206d15cb7da413c0e662f284e00f907f51999a40",
+      "https://snowtrace.io/address/0x206d15cb7da413c0e662f284e00f907f51999a40",
       "https://avascan.info/blockchain/c/address/0x206d15cb7da413c0e662f284e00f907f51999a40"
     ]
   },
@@ -2203,7 +2203,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-UNI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb58535a99e2d615df6ff00ad091d01310daabda3",
+      "https://snowtrace.io/address/0xb58535a99e2d615df6ff00ad091d01310daabda3",
       "https://avascan.info/blockchain/c/address/0xb58535a99e2d615df6ff00ad091d01310daabda3"
     ]
   },
@@ -2215,7 +2215,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-UNI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb88f392e8992d1fc4b54ffed5164bd548c238d95",
+      "https://snowtrace.io/address/0xb88f392e8992d1fc4b54ffed5164bd548c238d95",
       "https://avascan.info/blockchain/c/address/0xb88f392e8992d1fc4b54ffed5164bd548c238d95"
     ]
   },
@@ -2227,7 +2227,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-UNI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2521597a67dba56932358f0a67f196ba0cd33053",
+      "https://snowtrace.io/address/0x2521597a67dba56932358f0a67f196ba0cd33053",
       "https://avascan.info/blockchain/c/address/0x2521597a67dba56932358f0a67f196ba0cd33053"
     ]
   },
@@ -2239,7 +2239,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4e42c97efae0777643938262f43c247b702ad7c6",
+      "https://snowtrace.io/address/0x4e42c97efae0777643938262f43c247b702ad7c6",
       "https://avascan.info/blockchain/c/address/0x4e42c97efae0777643938262f43c247b702ad7c6"
     ]
   },
@@ -2251,7 +2251,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9099a81ddb2c6ee1fd3993e021e6c9179f84ccd1",
+      "https://snowtrace.io/address/0x9099a81ddb2c6ee1fd3993e021e6c9179f84ccd1",
       "https://avascan.info/blockchain/c/address/0x9099a81ddb2c6ee1fd3993e021e6c9179f84ccd1"
     ]
   },
@@ -2263,7 +2263,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe51d794d7822e5a78ba681a69294a31bf2117b94",
+      "https://snowtrace.io/address/0xe51d794d7822e5a78ba681a69294a31bf2117b94",
       "https://avascan.info/blockchain/c/address/0xe51d794d7822e5a78ba681a69294a31bf2117b94"
     ]
   },
@@ -2275,7 +2275,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-VSO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbfbbeb1bde34c53533a38cfbb07c37ffa06502a5",
+      "https://snowtrace.io/address/0xbfbbeb1bde34c53533a38cfbb07c37ffa06502a5",
       "https://avascan.info/blockchain/c/address/0xbfbbeb1bde34c53533a38cfbb07c37ffa06502a5"
     ]
   },
@@ -2287,7 +2287,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5d2e25ff380ae1e872bc23184af14ded67e3a29b",
+      "https://snowtrace.io/address/0x5d2e25ff380ae1e872bc23184af14ded67e3a29b",
       "https://avascan.info/blockchain/c/address/0x5d2e25ff380ae1e872bc23184af14ded67e3a29b"
     ]
   },
@@ -2299,7 +2299,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1817fe376740b53cae73224b7f0a57f23dd4c9b5",
+      "https://snowtrace.io/address/0x1817fe376740b53cae73224b7f0a57f23dd4c9b5",
       "https://avascan.info/blockchain/c/address/0x1817fe376740b53cae73224b7f0a57f23dd4c9b5"
     ]
   },
@@ -2311,7 +2311,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-YFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1ec356f7ea5a1cd8b479cf7a27c76a24b323d409",
+      "https://snowtrace.io/address/0x1ec356f7ea5a1cd8b479cf7a27c76a24b323d409",
       "https://avascan.info/blockchain/c/address/0x1ec356f7ea5a1cd8b479cf7a27c76a24b323d409"
     ]
   },
@@ -2323,7 +2323,7 @@
     "type": "core",
     "description": "PGL farm for AVAX-YFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf2a857ee56f568989da138653c044379c08f0657",
+      "https://snowtrace.io/address/0xf2a857ee56f568989da138653c044379c08f0657",
       "https://avascan.info/blockchain/c/address/0xf2a857ee56f568989da138653c044379c08f0657"
     ]
   },
@@ -2335,7 +2335,7 @@
     "type": "core",
     "description": "PGL farm for AVE-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfaed69427e2444263b4c62c630a872a289a54865",
+      "https://snowtrace.io/address/0xfaed69427e2444263b4c62c630a872a289a54865",
       "https://avascan.info/blockchain/c/address/0xfaed69427e2444263b4c62c630a872a289a54865"
     ]
   },
@@ -2347,7 +2347,7 @@
     "type": "core",
     "description": "PGL farm for AVME-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb34fe8a87dfebd5ab0a03db73f2d49b903e63db6",
+      "https://snowtrace.io/address/0xb34fe8a87dfebd5ab0a03db73f2d49b903e63db6",
       "https://avascan.info/blockchain/c/address/0xb34fe8a87dfebd5ab0a03db73f2d49b903e63db6"
     ]
   },
@@ -2359,7 +2359,7 @@
     "type": "core",
     "description": "PGL farm for BIRD-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf0c2d1d6a3d7fb3d1ddc2468fcf1d3b1ab648dac",
+      "https://snowtrace.io/address/0xf0c2d1d6a3d7fb3d1ddc2468fcf1d3b1ab648dac",
       "https://avascan.info/blockchain/c/address/0xf0c2d1d6a3d7fb3d1ddc2468fcf1d3b1ab648dac"
     ]
   },
@@ -2371,7 +2371,7 @@
     "type": "core",
     "description": "PGL farm for BIRD-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x43c1d15c34d73eb6dfd2bf39bc53c0a0b5724b17",
+      "https://snowtrace.io/address/0x43c1d15c34d73eb6dfd2bf39bc53c0a0b5724b17",
       "https://avascan.info/blockchain/c/address/0x43c1d15c34d73eb6dfd2bf39bc53c0a0b5724b17"
     ]
   },
@@ -2383,7 +2383,7 @@
     "type": "core",
     "description": "PGL farm for CYCLE-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe285a5cb85297a10fb65eb8fedbf3900ec242db8",
+      "https://snowtrace.io/address/0xe285a5cb85297a10fb65eb8fedbf3900ec242db8",
       "https://avascan.info/blockchain/c/address/0xe285a5cb85297a10fb65eb8fedbf3900ec242db8"
     ]
   },
@@ -2395,7 +2395,7 @@
     "type": "core",
     "description": "PGL farm for DAIe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x07d392a242a4e62919c316ff8eee210e4034ed20",
+      "https://snowtrace.io/address/0x07d392a242a4e62919c316ff8eee210e4034ed20",
       "https://avascan.info/blockchain/c/address/0x07d392a242a4e62919c316ff8eee210e4034ed20"
     ]
   },
@@ -2407,7 +2407,7 @@
     "type": "core",
     "description": "PGL farm for DAIe-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3683b47e3fe0a37e624fb82d60d593042b1920f1",
+      "https://snowtrace.io/address/0x3683b47e3fe0a37e624fb82d60d593042b1920f1",
       "https://avascan.info/blockchain/c/address/0x3683b47e3fe0a37e624fb82d60d593042b1920f1"
     ]
   },
@@ -2419,7 +2419,7 @@
     "type": "core",
     "description": "PGL farm for GAJ-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb7e864cb98896b8e348d31bda03c3524dc709041",
+      "https://snowtrace.io/address/0xb7e864cb98896b8e348d31bda03c3524dc709041",
       "https://avascan.info/blockchain/c/address/0xb7e864cb98896b8e348d31bda03c3524dc709041"
     ]
   },
@@ -2431,7 +2431,7 @@
     "type": "core",
     "description": "PGL farm for GAJ-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8dbdd4a46abe939a98b5876702bff56ea4cd33ad",
+      "https://snowtrace.io/address/0x8dbdd4a46abe939a98b5876702bff56ea4cd33ad",
       "https://avascan.info/blockchain/c/address/0x8dbdd4a46abe939a98b5876702bff56ea4cd33ad"
     ]
   },
@@ -2443,7 +2443,7 @@
     "type": "core",
     "description": "PGL farm for GDL-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfdd8b1444b3a929979d84e2255ab52cb9f7b5a4c",
+      "https://snowtrace.io/address/0xfdd8b1444b3a929979d84e2255ab52cb9f7b5a4c",
       "https://avascan.info/blockchain/c/address/0xfdd8b1444b3a929979d84e2255ab52cb9f7b5a4c"
     ]
   },
@@ -2455,7 +2455,7 @@
     "type": "core",
     "description": "PGL farm for LINKe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5be841f804be8f9825c85e728f9b7c8ee55da507",
+      "https://snowtrace.io/address/0x5be841f804be8f9825c85e728f9b7c8ee55da507",
       "https://avascan.info/blockchain/c/address/0x5be841f804be8f9825c85e728f9b7c8ee55da507"
     ]
   },
@@ -2467,7 +2467,7 @@
     "type": "core",
     "description": "PGL farm for LINKe-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x59280e53ac2202563ad3dd6ffdc5ee954c540501",
+      "https://snowtrace.io/address/0x59280e53ac2202563ad3dd6ffdc5ee954c540501",
       "https://avascan.info/blockchain/c/address/0x59280e53ac2202563ad3dd6ffdc5ee954c540501"
     ]
   },
@@ -2479,7 +2479,7 @@
     "type": "core",
     "description": "PGL farm for PEFI-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc474e6cae8b7c7e43b3c69125a7226a4a08a4229",
+      "https://snowtrace.io/address/0xc474e6cae8b7c7e43b3c69125a7226a4a08a4229",
       "https://avascan.info/blockchain/c/address/0xc474e6cae8b7c7e43b3c69125a7226a4a08a4229"
     ]
   },
@@ -2491,7 +2491,7 @@
     "type": "core",
     "description": "PGL farm for PEFI-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe97e85a8cc54980e0370faa196dae25e43b2aef0",
+      "https://snowtrace.io/address/0xe97e85a8cc54980e0370faa196dae25e43b2aef0",
       "https://avascan.info/blockchain/c/address/0xe97e85a8cc54980e0370faa196dae25e43b2aef0"
     ]
   },
@@ -2503,7 +2503,7 @@
     "type": "core",
     "description": "PGL farm for PNG-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8c325c11e06619ba0825010fed6d565b4fddc887",
+      "https://snowtrace.io/address/0x8c325c11e06619ba0825010fed6d565b4fddc887",
       "https://avascan.info/blockchain/c/address/0x8c325c11e06619ba0825010fed6d565b4fddc887"
     ]
   },
@@ -2515,7 +2515,7 @@
     "type": "core",
     "description": "PGL farm for PNG-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe867ec0fa1969380960fe544f2a8d5758a26e254",
+      "https://snowtrace.io/address/0xe867ec0fa1969380960fe544f2a8d5758a26e254",
       "https://avascan.info/blockchain/c/address/0xe867ec0fa1969380960fe544f2a8d5758a26e254"
     ]
   },
@@ -2527,7 +2527,7 @@
     "type": "core",
     "description": "PGL farm for PNG-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0bd7cddb6b76eeaa8aaaec124e7ffe0d26496d3e",
+      "https://snowtrace.io/address/0x0bd7cddb6b76eeaa8aaaec124e7ffe0d26496d3e",
       "https://avascan.info/blockchain/c/address/0x0bd7cddb6b76eeaa8aaaec124e7ffe0d26496d3e"
     ]
   },
@@ -2539,7 +2539,7 @@
     "type": "core",
     "description": "PGL farm for PNG-PEFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbd42169e094cd8b95513cb3640e9d37418258e17",
+      "https://snowtrace.io/address/0xbd42169e094cd8b95513cb3640e9d37418258e17",
       "https://avascan.info/blockchain/c/address/0xbd42169e094cd8b95513cb3640e9d37418258e17"
     ]
   },
@@ -2551,7 +2551,7 @@
     "type": "core",
     "description": "PGL farm for PNG-SNOB LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9550593ea20359a4efeb914c1fff2d123ec9c091",
+      "https://snowtrace.io/address/0x9550593ea20359a4efeb914c1fff2d123ec9c091",
       "https://avascan.info/blockchain/c/address/0x9550593ea20359a4efeb914c1fff2d123ec9c091"
     ]
   },
@@ -2563,7 +2563,7 @@
     "type": "core",
     "description": "PGL farm for PNG-SPORE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x816d5441c47d6d8fa62b28b6cb32ae7e72fb0e7a",
+      "https://snowtrace.io/address/0x816d5441c47d6d8fa62b28b6cb32ae7e72fb0e7a",
       "https://avascan.info/blockchain/c/address/0x816d5441c47d6d8fa62b28b6cb32ae7e72fb0e7a"
     ]
   },
@@ -2575,7 +2575,7 @@
     "type": "core",
     "description": "PGL farm for PNG-SPORE LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7832928758afd045ce857afe5b6320466b5c05ed",
+      "https://snowtrace.io/address/0x7832928758afd045ce857afe5b6320466b5c05ed",
       "https://avascan.info/blockchain/c/address/0x7832928758afd045ce857afe5b6320466b5c05ed"
     ]
   },
@@ -2587,7 +2587,7 @@
     "type": "core",
     "description": "PGL farm for PNG-SUSHI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x75e302c0f29f75813a1dbeb9fcadfdee48ebe362",
+      "https://snowtrace.io/address/0x75e302c0f29f75813a1dbeb9fcadfdee48ebe362",
       "https://avascan.info/blockchain/c/address/0x75e302c0f29f75813a1dbeb9fcadfdee48ebe362"
     ]
   },
@@ -2599,7 +2599,7 @@
     "type": "core",
     "description": "PGL farm for PNG-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb9c5ae872e946bb2b39f1cfbeb2749830ccf20fa",
+      "https://snowtrace.io/address/0xb9c5ae872e946bb2b39f1cfbeb2749830ccf20fa",
       "https://avascan.info/blockchain/c/address/0xb9c5ae872e946bb2b39f1cfbeb2749830ccf20fa"
     ]
   },
@@ -2611,7 +2611,7 @@
     "type": "core",
     "description": "PGL farm for PNG-VSO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2cfb60bd96b5215437c3e9d2cab218fce29f096c",
+      "https://snowtrace.io/address/0x2cfb60bd96b5215437c3e9d2cab218fce29f096c",
       "https://avascan.info/blockchain/c/address/0x2cfb60bd96b5215437c3e9d2cab218fce29f096c"
     ]
   },
@@ -2623,7 +2623,7 @@
     "type": "core",
     "description": "PGL farm for PNG-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf1854dce74e2e354ce6acb5daaa77a93690820d4",
+      "https://snowtrace.io/address/0xf1854dce74e2e354ce6acb5daaa77a93690820d4",
       "https://avascan.info/blockchain/c/address/0xf1854dce74e2e354ce6acb5daaa77a93690820d4"
     ]
   },
@@ -2635,7 +2635,7 @@
     "type": "core",
     "description": "PGL farm for QI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8e2dcd0f79c024c02a8d88a9c8c366e64bd8fea9",
+      "https://snowtrace.io/address/0x8e2dcd0f79c024c02a8d88a9c8c366e64bd8fea9",
       "https://avascan.info/blockchain/c/address/0x8e2dcd0f79c024c02a8d88a9c8c366e64bd8fea9"
     ]
   },
@@ -2647,7 +2647,7 @@
     "type": "core",
     "description": "PGL farm for QI-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5adcc735654bfa472e8c47a639b08292913ed773",
+      "https://snowtrace.io/address/0x5adcc735654bfa472e8c47a639b08292913ed773",
       "https://avascan.info/blockchain/c/address/0x5adcc735654bfa472e8c47a639b08292913ed773"
     ]
   },
@@ -2659,7 +2659,7 @@
     "type": "core",
     "description": "PGL farm for SNOB-PEFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6b128f920813df43ac91d83ed8a79b08c99a41db",
+      "https://snowtrace.io/address/0x6b128f920813df43ac91d83ed8a79b08c99a41db",
       "https://avascan.info/blockchain/c/address/0x6b128f920813df43ac91d83ed8a79b08c99a41db"
     ]
   },
@@ -2671,7 +2671,7 @@
     "type": "core",
     "description": "PGL farm for STORM-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe84bc4114f38d7259d04ce53df8aaa784dd6680d",
+      "https://snowtrace.io/address/0xe84bc4114f38d7259d04ce53df8aaa784dd6680d",
       "https://avascan.info/blockchain/c/address/0xe84bc4114f38d7259d04ce53df8aaa784dd6680d"
     ]
   },
@@ -2683,7 +2683,7 @@
     "type": "core",
     "description": "PGL farm for STORM-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xbb0841e1b782e001af08cdd5097a7a09162b9ec6",
+      "https://snowtrace.io/address/0xbb0841e1b782e001af08cdd5097a7a09162b9ec6",
       "https://avascan.info/blockchain/c/address/0xbb0841e1b782e001af08cdd5097a7a09162b9ec6"
     ]
   },
@@ -2695,7 +2695,7 @@
     "type": "core",
     "description": "PGL farm for SUSHI-PEFI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x976eeea238514fd13a4ab3e4cb45efa17f9426a7",
+      "https://snowtrace.io/address/0x976eeea238514fd13a4ab3e4cb45efa17f9426a7",
       "https://avascan.info/blockchain/c/address/0x976eeea238514fd13a4ab3e4cb45efa17f9426a7"
     ]
   },
@@ -2707,7 +2707,7 @@
     "type": "core",
     "description": "PGL farm for TUNDRA-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2ec16d231f4001153dd84da477455d0bcb7d5c71",
+      "https://snowtrace.io/address/0x2ec16d231f4001153dd84da477455d0bcb7d5c71",
       "https://avascan.info/blockchain/c/address/0x2ec16d231f4001153dd84da477455d0bcb7d5c71"
     ]
   },
@@ -2719,7 +2719,7 @@
     "type": "core",
     "description": "PGL farm for TUNDRA-DAIe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfb503e8cc1657adeb1a7ed40a0d7ae77ececaafd",
+      "https://snowtrace.io/address/0xfb503e8cc1657adeb1a7ed40a0d7ae77ececaafd",
       "https://avascan.info/blockchain/c/address/0xfb503e8cc1657adeb1a7ed40a0d7ae77ececaafd"
     ]
   },
@@ -2731,7 +2731,7 @@
     "type": "core",
     "description": "PGL farm for TUNDRA-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x942b94a79fbe8ae12594ee4510619b5209d4a6d4",
+      "https://snowtrace.io/address/0x942b94a79fbe8ae12594ee4510619b5209d4a6d4",
       "https://avascan.info/blockchain/c/address/0x942b94a79fbe8ae12594ee4510619b5209d4a6d4"
     ]
   },
@@ -2743,7 +2743,7 @@
     "type": "core",
     "description": "PGL farm for USDCe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4647247005a15594d16a226867812f509c4557ed",
+      "https://snowtrace.io/address/0x4647247005a15594d16a226867812f509c4557ed",
       "https://avascan.info/blockchain/c/address/0x4647247005a15594d16a226867812f509c4557ed"
     ]
   },
@@ -2755,7 +2755,7 @@
     "type": "core",
     "description": "PGL farm for USDCe-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x14d35e27d1381c73aa748f39eca82c6e6f759392",
+      "https://snowtrace.io/address/0x14d35e27d1381c73aa748f39eca82c6e6f759392",
       "https://avascan.info/blockchain/c/address/0x14d35e27d1381c73aa748f39eca82c6e6f759392"
     ]
   },
@@ -2767,7 +2767,7 @@
     "type": "core",
     "description": "PGL farm for USDTe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x54ee73d619d332e360bb3895ee1647e18dcd21f7",
+      "https://snowtrace.io/address/0x54ee73d619d332e360bb3895ee1647e18dcd21f7",
       "https://avascan.info/blockchain/c/address/0x54ee73d619d332e360bb3895ee1647e18dcd21f7"
     ]
   },
@@ -2779,7 +2779,7 @@
     "type": "core",
     "description": "PGL farm for USDTe-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc5d0eff84ff61a8a6b6ccf6852506afb51fe803f",
+      "https://snowtrace.io/address/0xc5d0eff84ff61a8a6b6ccf6852506afb51fe803f",
       "https://avascan.info/blockchain/c/address/0xc5d0eff84ff61a8a6b6ccf6852506afb51fe803f"
     ]
   },
@@ -2791,7 +2791,7 @@
     "type": "core",
     "description": "PGL farm for WBTCe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6296043f1ce18a94ee61a9d6da99281197d73a00",
+      "https://snowtrace.io/address/0x6296043f1ce18a94ee61a9d6da99281197d73a00",
       "https://avascan.info/blockchain/c/address/0x6296043f1ce18a94ee61a9d6da99281197d73a00"
     ]
   },
@@ -2803,7 +2803,7 @@
     "type": "core",
     "description": "PGL farm for WETHe-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf3072d053eacfab3adca9edde5913610566d82d6",
+      "https://snowtrace.io/address/0xf3072d053eacfab3adca9edde5913610566d82d6",
       "https://avascan.info/blockchain/c/address/0xf3072d053eacfab3adca9edde5913610566d82d6"
     ]
   },
@@ -2815,7 +2815,7 @@
     "type": "core",
     "description": "PGL farm for WETHe-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x093dcad3a5257457746de4c614f983b23b982602",
+      "https://snowtrace.io/address/0x093dcad3a5257457746de4c614f983b23b982602",
       "https://avascan.info/blockchain/c/address/0x093dcad3a5257457746de4c614f983b23b982602"
     ]
   },
@@ -2827,7 +2827,7 @@
     "type": "core",
     "description": "PGL farm for XAVA-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9d2935dcb0225cd79169cb71f45157cffc6cdd42",
+      "https://snowtrace.io/address/0x9d2935dcb0225cd79169cb71f45157cffc6cdd42",
       "https://avascan.info/blockchain/c/address/0x9d2935dcb0225cd79169cb71f45157cffc6cdd42"
     ]
   },
@@ -2839,7 +2839,7 @@
     "type": "core",
     "description": "PGL farm for XAVA-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9b3365cf1927c29fa6c1d9bbd214a6bf7b893a06",
+      "https://snowtrace.io/address/0x9b3365cf1927c29fa6c1d9bbd214a6bf7b893a06",
       "https://avascan.info/blockchain/c/address/0x9b3365cf1927c29fa6c1d9bbd214a6bf7b893a06"
     ]
   },
@@ -2851,7 +2851,7 @@
     "type": "core",
     "description": "PGL farm for XAVA-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x08337a1549166dcc463279b68f0028b2f0515b0b",
+      "https://snowtrace.io/address/0x08337a1549166dcc463279b68f0028b2f0515b0b",
       "https://avascan.info/blockchain/c/address/0x08337a1549166dcc463279b68f0028b2f0515b0b"
     ]
   },
@@ -2863,7 +2863,7 @@
     "type": "core",
     "description": "PGL farm for YAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe8326e606793bf60a7a9ee13aaee1c06b3d4e491",
+      "https://snowtrace.io/address/0xe8326e606793bf60a7a9ee13aaee1c06b3d4e491",
       "https://avascan.info/blockchain/c/address/0xe8326e606793bf60a7a9ee13aaee1c06b3d4e491"
     ]
   },
@@ -2875,7 +2875,7 @@
     "type": "core",
     "description": "PGL farm for YAK-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2d5c943ee961b7dc605ca192a19fd0fe9258ac5f",
+      "https://snowtrace.io/address/0x2d5c943ee961b7dc605ca192a19fd0fe9258ac5f",
       "https://avascan.info/blockchain/c/address/0x2d5c943ee961b7dc605ca192a19fd0fe9258ac5f"
     ]
   },
@@ -2887,7 +2887,7 @@
     "type": "core",
     "description": "PGL farm for YAK-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0e3aae51740325e41351103ad4a0594900100b43",
+      "https://snowtrace.io/address/0x0e3aae51740325e41351103ad4a0594900100b43",
       "https://avascan.info/blockchain/c/address/0x0e3aae51740325e41351103ad4a0594900100b43"
     ]
   },
@@ -2899,7 +2899,7 @@
     "type": "core",
     "description": "PGL farm for ZABU-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x38056b8ad79256cecf7a2ab6103a9c00abe61214",
+      "https://snowtrace.io/address/0x38056b8ad79256cecf7a2ab6103a9c00abe61214",
       "https://avascan.info/blockchain/c/address/0x38056b8ad79256cecf7a2ab6103a9c00abe61214"
     ]
   },
@@ -2911,7 +2911,7 @@
     "type": "core",
     "description": "PGL farm for ZABU-USDTe LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd3f113cfc44a5e28a6683a2d0424d3ea6ccc2ac0",
+      "https://snowtrace.io/address/0xd3f113cfc44a5e28a6683a2d0424d3ea6ccc2ac0",
       "https://avascan.info/blockchain/c/address/0xd3f113cfc44a5e28a6683a2d0424d3ea6ccc2ac0"
     ]
   },
@@ -2923,7 +2923,7 @@
     "type": "core",
     "description": "PLP farm for BAMBOO-V2 LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x37a83906a69d6236dbcb4d8257d8f62d1f3bbcd5",
+      "https://snowtrace.io/address/0x37a83906a69d6236dbcb4d8257d8f62d1f3bbcd5",
       "https://avascan.info/blockchain/c/address/0x37a83906a69d6236dbcb4d8257d8f62d1f3bbcd5"
     ]
   },
@@ -2935,7 +2935,7 @@
     "type": "core",
     "description": "PLP farm for AVAX-BAMBOO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf0bde208a05cc0a056b5fae1a78212adf7a4affe",
+      "https://snowtrace.io/address/0xf0bde208a05cc0a056b5fae1a78212adf7a4affe",
       "https://avascan.info/blockchain/c/address/0xf0bde208a05cc0a056b5fae1a78212adf7a4affe"
     ]
   },
@@ -2947,7 +2947,7 @@
     "type": "core",
     "description": "PLP farm for BTC-V2 LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdefc4b949ea970533fe6f5a75248d4da534f8873",
+      "https://snowtrace.io/address/0xdefc4b949ea970533fe6f5a75248d4da534f8873",
       "https://avascan.info/blockchain/c/address/0xdefc4b949ea970533fe6f5a75248d4da534f8873"
     ]
   },
@@ -2959,7 +2959,7 @@
     "type": "core",
     "description": "PLP farm for AVAX-BTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x06fd3ecee685ca5717c814dc7a790641e98ad9c7",
+      "https://snowtrace.io/address/0x06fd3ecee685ca5717c814dc7a790641e98ad9c7",
       "https://avascan.info/blockchain/c/address/0x06fd3ecee685ca5717c814dc7a790641e98ad9c7"
     ]
   },
@@ -2971,7 +2971,7 @@
     "type": "core",
     "description": "PLP farm for ETH-Strategy LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe8f4423a2ab1bf71712cc5de8fbad4caa42b101c",
+      "https://snowtrace.io/address/0xe8f4423a2ab1bf71712cc5de8fbad4caa42b101c",
       "https://avascan.info/blockchain/c/address/0xe8f4423a2ab1bf71712cc5de8fbad4caa42b101c"
     ]
   },
@@ -2983,7 +2983,7 @@
     "type": "core",
     "description": "PLP farm for ETH-V2 LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0b4a63943e96463b432ec79e7287e63d830bec51",
+      "https://snowtrace.io/address/0x0b4a63943e96463b432ec79e7287e63d830bec51",
       "https://avascan.info/blockchain/c/address/0x0b4a63943e96463b432ec79e7287e63d830bec51"
     ]
   },
@@ -2995,7 +2995,7 @@
     "type": "core",
     "description": "PLP farm for ETH-Vault LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd335117acc6bf8b829fa0687776fe99b3888fbfd",
+      "https://snowtrace.io/address/0xd335117acc6bf8b829fa0687776fe99b3888fbfd",
       "https://avascan.info/blockchain/c/address/0xd335117acc6bf8b829fa0687776fe99b3888fbfd"
     ]
   },
@@ -3007,7 +3007,7 @@
     "type": "core",
     "description": "PLP farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc0787fd12249451763be576cf73621f3af61ebbd",
+      "https://snowtrace.io/address/0xc0787fd12249451763be576cf73621f3af61ebbd",
       "https://avascan.info/blockchain/c/address/0xc0787fd12249451763be576cf73621f3af61ebbd"
     ]
   },
@@ -3019,7 +3019,7 @@
     "type": "core",
     "description": "PLP farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x00508fd84e2aca19b8af38c2c59171971d97495b",
+      "https://snowtrace.io/address/0x00508fd84e2aca19b8af38c2c59171971d97495b",
       "https://avascan.info/blockchain/c/address/0x00508fd84e2aca19b8af38c2c59171971d97495b"
     ]
   },
@@ -3031,7 +3031,7 @@
     "type": "core",
     "description": "PLP farm for DAI-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x43801e030afbdfd9a30da3e5321dd6b609083bcb",
+      "https://snowtrace.io/address/0x43801e030afbdfd9a30da3e5321dd6b609083bcb",
       "https://avascan.info/blockchain/c/address/0x43801e030afbdfd9a30da3e5321dd6b609083bcb"
     ]
   },
@@ -3043,7 +3043,7 @@
     "type": "core",
     "description": "PLP farm for WBTC-V2 LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x69293f1f9f4ad45ef9295f94ccaed0c045466214",
+      "https://snowtrace.io/address/0x69293f1f9f4ad45ef9295f94ccaed0c045466214",
       "https://avascan.info/blockchain/c/address/0x69293f1f9f4ad45ef9295f94ccaed0c045466214"
     ]
   },
@@ -3055,7 +3055,7 @@
     "type": "core",
     "description": "PLP farm for ETH-WBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaa9e134d3f9c802f099c53a0c0195373e34d92f7",
+      "https://snowtrace.io/address/0xaa9e134d3f9c802f099c53a0c0195373e34d92f7",
       "https://avascan.info/blockchain/c/address/0xaa9e134d3f9c802f099c53a0c0195373e34d92f7"
     ]
   },
@@ -3067,7 +3067,7 @@
     "type": "core",
     "description": "PLP farm for BAMBOO-V2 LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4a79206b5e1af8ff4e62183f2f2ff2b4efb0a9b9",
+      "https://snowtrace.io/address/0x4a79206b5e1af8ff4e62183f2f2ff2b4efb0a9b9",
       "https://avascan.info/blockchain/c/address/0x4a79206b5e1af8ff4e62183f2f2ff2b4efb0a9b9"
     ]
   },
@@ -3079,7 +3079,7 @@
     "type": "core",
     "description": "PNG farm for compounding PNG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdddddfeb2db092a84f27893a040b2bfede8be074",
+      "https://snowtrace.io/address/0xdddddfeb2db092a84f27893a040b2bfede8be074",
       "https://avascan.info/blockchain/c/address/0xdddddfeb2db092a84f27893a040b2bfede8be074"
     ]
   },
@@ -3091,7 +3091,7 @@
     "type": "core",
     "description": "Helper files",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8cd1eb470226f63f6514666bfba6a12f1603b297",
+      "https://snowtrace.io/address/0x8cd1eb470226f63f6514666bfba6a12f1603b297",
       "https://avascan.info/blockchain/c/address/0x8cd1eb470226f63f6514666bfba6a12f1603b297"
     ]
   },
@@ -3103,7 +3103,7 @@
     "type": "core",
     "description": "SNOB farm for compounding S3D",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8d9153c1976769e2c8774f88648e75c897d1e4b0",
+      "https://snowtrace.io/address/0x8d9153c1976769e2c8774f88648e75c897d1e4b0",
       "https://avascan.info/blockchain/c/address/0x8d9153c1976769e2c8774f88648e75c897d1e4b0"
     ]
   },
@@ -3115,7 +3115,7 @@
     "type": "core",
     "description": "SNOB farm for compounding S3F",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc1f14e9d2b7b88b62e33772b3d14bc6d360d7cdb",
+      "https://snowtrace.io/address/0xc1f14e9d2b7b88b62e33772b3d14bc6d360d7cdb",
       "https://avascan.info/blockchain/c/address/0xc1f14e9d2b7b88b62e33772b3d14bc6d360d7cdb"
     ]
   },
@@ -3127,7 +3127,7 @@
     "type": "core",
     "description": "STORM farm for compounding DAIe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xab4f4a38bc4f74116259174835f67035e973b885",
+      "https://snowtrace.io/address/0xab4f4a38bc4f74116259174835f67035e973b885",
       "https://avascan.info/blockchain/c/address/0xab4f4a38bc4f74116259174835f67035e973b885"
     ]
   },
@@ -3139,7 +3139,7 @@
     "type": "core",
     "description": "STORM farm for compounding JOE",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x92984ce5878ce56f65218cbc1957c99b2573ec3b",
+      "https://snowtrace.io/address/0x92984ce5878ce56f65218cbc1957c99b2573ec3b",
       "https://avascan.info/blockchain/c/address/0x92984ce5878ce56f65218cbc1957c99b2573ec3b"
     ]
   },
@@ -3151,7 +3151,7 @@
     "type": "core",
     "description": "STORM farm for compounding JOE",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1cf9398d088fe72f18ae4f0dd056bc19bf02d00b",
+      "https://snowtrace.io/address/0x1cf9398d088fe72f18ae4f0dd056bc19bf02d00b",
       "https://avascan.info/blockchain/c/address/0x1cf9398d088fe72f18ae4f0dd056bc19bf02d00b"
     ]
   },
@@ -3163,7 +3163,7 @@
     "type": "core",
     "description": "STORM farm for compounding PNG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xff40eb068d35bb24f1e43cdb38fd342e2aa58af7",
+      "https://snowtrace.io/address/0xff40eb068d35bb24f1e43cdb38fd342e2aa58af7",
       "https://avascan.info/blockchain/c/address/0xff40eb068d35bb24f1e43cdb38fd342e2aa58af7"
     ]
   },
@@ -3175,7 +3175,7 @@
     "type": "core",
     "description": "STORM farm for compounding PNG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x16a97496d7f7b8e2d38a0788d0a811bb08faa484",
+      "https://snowtrace.io/address/0x16a97496d7f7b8e2d38a0788d0a811bb08faa484",
       "https://avascan.info/blockchain/c/address/0x16a97496d7f7b8e2d38a0788d0a811bb08faa484"
     ]
   },
@@ -3187,7 +3187,7 @@
     "type": "core",
     "description": "STORM farm for compounding QI",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x51132860f3c6947aeb3cb8139121f4d5ff6aa6d4",
+      "https://snowtrace.io/address/0x51132860f3c6947aeb3cb8139121f4d5ff6aa6d4",
       "https://avascan.info/blockchain/c/address/0x51132860f3c6947aeb3cb8139121f4d5ff6aa6d4"
     ]
   },
@@ -3199,7 +3199,7 @@
     "type": "core",
     "description": "STORM farm for compounding STORM",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xf8571832675f27a26e7d152394fc07246bd33b91",
+      "https://snowtrace.io/address/0xf8571832675f27a26e7d152394fc07246bd33b91",
       "https://avascan.info/blockchain/c/address/0xf8571832675f27a26e7d152394fc07246bd33b91"
     ]
   },
@@ -3211,7 +3211,7 @@
     "type": "core",
     "description": "STORM farm for compounding USDCe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xe40dd09cbe02419d2be363f55200c72bca617404",
+      "https://snowtrace.io/address/0xe40dd09cbe02419d2be363f55200c72bca617404",
       "https://avascan.info/blockchain/c/address/0xe40dd09cbe02419d2be363f55200c72bca617404"
     ]
   },
@@ -3223,7 +3223,7 @@
     "type": "core",
     "description": "STORM farm for compounding USDTe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x19d579dfa6a41c9215f1a55b810d59f254f6a8fc",
+      "https://snowtrace.io/address/0x19d579dfa6a41c9215f1a55b810d59f254f6a8fc",
       "https://avascan.info/blockchain/c/address/0x19d579dfa6a41c9215f1a55b810d59f254f6a8fc"
     ]
   },
@@ -3235,7 +3235,7 @@
     "type": "core",
     "description": "STORM farm for compounding WAVAX",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5f02327fc088f8db5fa8f5a9992aebdc33450d1f",
+      "https://snowtrace.io/address/0x5f02327fc088f8db5fa8f5a9992aebdc33450d1f",
       "https://avascan.info/blockchain/c/address/0x5f02327fc088f8db5fa8f5a9992aebdc33450d1f"
     ]
   },
@@ -3247,7 +3247,7 @@
     "type": "core",
     "description": "STORM farm for compounding WBTCe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdd1c67481a12c8314aa834d6c96a6530ccfb9da9",
+      "https://snowtrace.io/address/0xdd1c67481a12c8314aa834d6c96a6530ccfb9da9",
       "https://avascan.info/blockchain/c/address/0xdd1c67481a12c8314aa834d6c96a6530ccfb9da9"
     ]
   },
@@ -3259,7 +3259,7 @@
     "type": "core",
     "description": "STORM farm for compounding WETHe",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x32e4f703d6eb770f4e1fd8abc4dae35f1a420291",
+      "https://snowtrace.io/address/0x32e4f703d6eb770f4e1fd8abc4dae35f1a420291",
       "https://avascan.info/blockchain/c/address/0x32e4f703d6eb770f4e1fd8abc4dae35f1a420291"
     ]
   },
@@ -3271,7 +3271,7 @@
     "type": "core",
     "description": "STORM farm for compounding YAK",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x23576f938a7923e3f4e419831b35489adb0494e4",
+      "https://snowtrace.io/address/0x23576f938a7923e3f4e419831b35489adb0494e4",
       "https://avascan.info/blockchain/c/address/0x23576f938a7923e3f4e419831b35489adb0494e4"
     ]
   },
@@ -3283,7 +3283,7 @@
     "type": "core",
     "description": "Helper files",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x462e05962eb9938ce73e59ccb7b7ae287ff8bd17",
+      "https://snowtrace.io/address/0x462e05962eb9938ce73e59ccb7b7ae287ff8bd17",
       "https://avascan.info/blockchain/c/address/0x462e05962eb9938ce73e59ccb7b7ae287ff8bd17"
     ]
   },
@@ -3295,7 +3295,7 @@
     "type": "core",
     "description": "TEDDY farm for TEDDY-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x56e2492a926e419c6711e257b6be5e4491220b92",
+      "https://snowtrace.io/address/0x56e2492a926e419c6711e257b6be5e4491220b92",
       "https://avascan.info/blockchain/c/address/0x56e2492a926e419c6711e257b6be5e4491220b92"
     ]
   },
@@ -3307,7 +3307,7 @@
     "type": "core",
     "description": "Time lock contract",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6fd41a93c2902b48d9de81158389ef7b95c338f5",
+      "https://snowtrace.io/address/0x6fd41a93c2902b48d9de81158389ef7b95c338f5",
       "https://avascan.info/blockchain/c/address/0x6fd41a93c2902b48d9de81158389ef7b95c338f5"
     ]
   },
@@ -3319,7 +3319,7 @@
     "type": "core",
     "description": "Time lock contract",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8d36c5c6947adccd25ef49ea1aac2ceacfff0bd7",
+      "https://snowtrace.io/address/0x8d36c5c6947adccd25ef49ea1aac2ceacfff0bd7",
       "https://avascan.info/blockchain/c/address/0x8d36c5c6947adccd25ef49ea1aac2ceacfff0bd7"
     ]
   },
@@ -3331,7 +3331,7 @@
     "type": "core",
     "description": "XAVA farm for compounding XAVA",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7867c7a94ef30e26ae855af5d271fb9e52f26c36",
+      "https://snowtrace.io/address/0x7867c7a94ef30e26ae855af5d271fb9e52f26c36",
       "https://avascan.info/blockchain/c/address/0x7867c7a94ef30e26ae855af5d271fb9e52f26c36"
     ]
   },
@@ -3343,7 +3343,7 @@
     "type": "core",
     "description": "YAK farm for compounding YAK",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0c4684086914d5b1525bf16c62a0ff8010ab991a",
+      "https://snowtrace.io/address/0x0c4684086914d5b1525bf16c62a0ff8010ab991a",
       "https://avascan.info/blockchain/c/address/0x0c4684086914d5b1525bf16c62a0ff8010ab991a"
     ]
   },
@@ -3355,7 +3355,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x007a0f7c4cae14415dbcac83da92d4c01f7601ed",
+      "https://snowtrace.io/address/0x007a0f7c4cae14415dbcac83da92d4c01f7601ed",
       "https://avascan.info/blockchain/c/address/0x007a0f7c4cae14415dbcac83da92d4c01f7601ed"
     ]
   },
@@ -3367,7 +3367,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1ad92f75c2740efd143ed666f8de3ed963b22ad3",
+      "https://snowtrace.io/address/0x1ad92f75c2740efd143ed666f8de3ed963b22ad3",
       "https://avascan.info/blockchain/c/address/0x1ad92f75c2740efd143ed666f8de3ed963b22ad3"
     ]
   },
@@ -3379,7 +3379,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8054faba5fc1b8523a0c2fb54845c2ec3326b347",
+      "https://snowtrace.io/address/0x8054faba5fc1b8523a0c2fb54845c2ec3326b347",
       "https://avascan.info/blockchain/c/address/0x8054faba5fc1b8523a0c2fb54845c2ec3326b347"
     ]
   },
@@ -3391,7 +3391,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x72e332cc6bf00ec48861c51df104770edf7890b6",
+      "https://snowtrace.io/address/0x72e332cc6bf00ec48861c51df104770edf7890b6",
       "https://avascan.info/blockchain/c/address/0x72e332cc6bf00ec48861c51df104770edf7890b6"
     ]
   },
@@ -3403,7 +3403,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-YTS LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x303dff9550a1e959a7e6731809a587acc195fd21",
+      "https://snowtrace.io/address/0x303dff9550a1e959a7e6731809a587acc195fd21",
       "https://avascan.info/blockchain/c/address/0x303dff9550a1e959a7e6731809a587acc195fd21"
     ]
   },
@@ -3415,7 +3415,7 @@
     "type": "core",
     "description": "YSL farm for AVAX-YTS LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0345f2b85d238a963965ef8163ccb93eff81ff5e",
+      "https://snowtrace.io/address/0x0345f2b85d238a963965ef8163ccb93eff81ff5e",
       "https://avascan.info/blockchain/c/address/0x0345f2b85d238a963965ef8163ccb93eff81ff5e"
     ]
   },
@@ -3427,7 +3427,7 @@
     "type": "core",
     "description": "YSL farm for YTS-ETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2409e04f96e71fc931e18196509f130dfe0959a6",
+      "https://snowtrace.io/address/0x2409e04f96e71fc931e18196509f130dfe0959a6",
       "https://avascan.info/blockchain/c/address/0x2409e04f96e71fc931e18196509f130dfe0959a6"
     ]
   },
@@ -3439,7 +3439,7 @@
     "type": "core",
     "description": "YSL farm for YTS-PNG LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc53dc280dc14f24b21370919d757cf7b296bfd31",
+      "https://snowtrace.io/address/0xc53dc280dc14f24b21370919d757cf7b296bfd31",
       "https://avascan.info/blockchain/c/address/0xc53dc280dc14f24b21370919d757cf7b296bfd31"
     ]
   },
@@ -3451,7 +3451,7 @@
     "type": "core",
     "description": "YSL farm for YTS-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xaf985c13836b753445487c99448da38bd7774a17",
+      "https://snowtrace.io/address/0xaf985c13836b753445487c99448da38bd7774a17",
       "https://avascan.info/blockchain/c/address/0xaf985c13836b753445487c99448da38bd7774a17"
     ]
   },
@@ -3463,7 +3463,7 @@
     "type": "core",
     "description": "ZABU farm for compounding PNG",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xcfd132761c41f66a188a478a282121b0fb6d99bf",
+      "https://snowtrace.io/address/0xcfd132761c41f66a188a478a282121b0fb6d99bf",
       "https://avascan.info/blockchain/c/address/0xcfd132761c41f66a188a478a282121b0fb6d99bf"
     ]
   },
@@ -3475,7 +3475,7 @@
     "type": "core",
     "description": "ZABU farm for compounding WAVAX",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x150f6526de9b55e126870a118d47dc4fd0f8ac48",
+      "https://snowtrace.io/address/0x150f6526de9b55e126870a118d47dc4fd0f8ac48",
       "https://avascan.info/blockchain/c/address/0x150f6526de9b55e126870a118d47dc4fd0f8ac48"
     ]
   },
@@ -3487,7 +3487,7 @@
     "type": "core",
     "description": "ZABU farm for compounding XAVA",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x4d94796eee7694e5c60cd850ef47d9e536d3ad8b",
+      "https://snowtrace.io/address/0x4d94796eee7694e5c60cd850ef47d9e536d3ad8b",
       "https://avascan.info/blockchain/c/address/0x4d94796eee7694e5c60cd850ef47d9e536d3ad8b"
     ]
   },
@@ -3499,7 +3499,7 @@
     "type": "core",
     "description": "ZABU farm for compounding YAK",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x3e63f20cdd82a9fec2bbe48ca820589afcb85194",
+      "https://snowtrace.io/address/0x3e63f20cdd82a9fec2bbe48ca820589afcb85194",
       "https://avascan.info/blockchain/c/address/0x3e63f20cdd82a9fec2bbe48ca820589afcb85194"
     ]
   },
@@ -3511,7 +3511,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-CHART LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc92fac369925f6f6e88384c2a6f3678977dc6213",
+      "https://snowtrace.io/address/0xc92fac369925f6f6e88384c2a6f3678977dc6213",
       "https://avascan.info/blockchain/c/address/0xc92fac369925f6f6e88384c2a6f3678977dc6213"
     ]
   },
@@ -3523,7 +3523,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-ZERO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xc47c5050e1f8e45a6741613e29a303d7cc106aff",
+      "https://snowtrace.io/address/0xc47c5050e1f8e45a6741613e29a303d7cc106aff",
       "https://avascan.info/blockchain/c/address/0xc47c5050e1f8e45a6741613e29a303d7cc106aff"
     ]
   },
@@ -3535,7 +3535,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-ZERO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6bbea2dba0ea15f17c92f84765ae1c3ab651df58",
+      "https://snowtrace.io/address/0x6bbea2dba0ea15f17c92f84765ae1c3ab651df58",
       "https://avascan.info/blockchain/c/address/0x6bbea2dba0ea15f17c92f84765ae1c3ab651df58"
     ]
   },
@@ -3547,7 +3547,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-ZERO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xb2da66e3245d47b67ea0d98b8789c614e2e3a76d",
+      "https://snowtrace.io/address/0xb2da66e3245d47b67ea0d98b8789c614e2e3a76d",
       "https://avascan.info/blockchain/c/address/0xb2da66e3245d47b67ea0d98b8789c614e2e3a76d"
     ]
   },
@@ -3559,7 +3559,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-zETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x456a68eec203a35a8fa1d9c7bf5797909d1cee04",
+      "https://snowtrace.io/address/0x456a68eec203a35a8fa1d9c7bf5797909d1cee04",
       "https://avascan.info/blockchain/c/address/0x456a68eec203a35a8fa1d9c7bf5797909d1cee04"
     ]
   },
@@ -3571,7 +3571,7 @@
     "type": "core",
     "description": "ZERO farm for AVAX-zUSDC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6ea142f55ae733eeaeef5fea34d4312478c762e5",
+      "https://snowtrace.io/address/0x6ea142f55ae733eeaeef5fea34d4312478c762e5",
       "https://avascan.info/blockchain/c/address/0x6ea142f55ae733eeaeef5fea34d4312478c762e5"
     ]
   },
@@ -3583,7 +3583,7 @@
     "type": "core",
     "description": "ZERO farm for CHART-zUSDC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x7924612c49084b71eaa383c3aeb8a7e7eeb1a63e",
+      "https://snowtrace.io/address/0x7924612c49084b71eaa383c3aeb8a7e7eeb1a63e",
       "https://avascan.info/blockchain/c/address/0x7924612c49084b71eaa383c3aeb8a7e7eeb1a63e"
     ]
   },
@@ -3595,7 +3595,7 @@
     "type": "core",
     "description": "ZERO farm for GDL-ZERO LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xdf98af02258e7f32a4feb77c159a42bd64d204d3",
+      "https://snowtrace.io/address/0xdf98af02258e7f32a4feb77c159a42bd64d204d3",
       "https://avascan.info/blockchain/c/address/0xdf98af02258e7f32a4feb77c159a42bd64d204d3"
     ]
   },
@@ -3607,7 +3607,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-CHART LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x81dbdb246fa1bb98a85c59eaf9face97403b6c19",
+      "https://snowtrace.io/address/0x81dbdb246fa1bb98a85c59eaf9face97403b6c19",
       "https://avascan.info/blockchain/c/address/0x81dbdb246fa1bb98a85c59eaf9face97403b6c19"
     ]
   },
@@ -3619,7 +3619,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-DAI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xfe0521f000d20f0bb9bb2cba51dc9066468671f9",
+      "https://snowtrace.io/address/0xfe0521f000d20f0bb9bb2cba51dc9066468671f9",
       "https://avascan.info/blockchain/c/address/0xfe0521f000d20f0bb9bb2cba51dc9066468671f9"
     ]
   },
@@ -3631,7 +3631,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-ZUSDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x86d919752822fcf060307201808e8f206ad10324",
+      "https://snowtrace.io/address/0x86d919752822fcf060307201808e8f206ad10324",
       "https://avascan.info/blockchain/c/address/0x86d919752822fcf060307201808e8f206ad10324"
     ]
   },
@@ -3643,7 +3643,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zBTC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x485240fd6e73ec6afd32a7c64707f7aac11ee151",
+      "https://snowtrace.io/address/0x485240fd6e73ec6afd32a7c64707f7aac11ee151",
       "https://avascan.info/blockchain/c/address/0x485240fd6e73ec6afd32a7c64707f7aac11ee151"
     ]
   },
@@ -3655,7 +3655,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x49e01ade31690d286c5e820a8daa4412125c7e7a",
+      "https://snowtrace.io/address/0x49e01ade31690d286c5e820a8daa4412125c7e7a",
       "https://avascan.info/blockchain/c/address/0x49e01ade31690d286c5e820a8daa4412125c7e7a"
     ]
   },
@@ -3667,7 +3667,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zETH LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xca0803b898f64e3a990998a79ad874c1880ba346",
+      "https://snowtrace.io/address/0xca0803b898f64e3a990998a79ad874c1880ba346",
       "https://avascan.info/blockchain/c/address/0xca0803b898f64e3a990998a79ad874c1880ba346"
     ]
   },
@@ -3679,7 +3679,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zSUSHI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x411b1f257e84394a60c7fb8fbda9c53a0c441057",
+      "https://snowtrace.io/address/0x411b1f257e84394a60c7fb8fbda9c53a0c441057",
       "https://avascan.info/blockchain/c/address/0x411b1f257e84394a60c7fb8fbda9c53a0c441057"
     ]
   },
@@ -3691,7 +3691,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zUNI LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xd8399d3db7da1e1db132de4e5d3ccf8620dfa2e6",
+      "https://snowtrace.io/address/0xd8399d3db7da1e1db132de4e5d3ccf8620dfa2e6",
       "https://avascan.info/blockchain/c/address/0xd8399d3db7da1e1db132de4e5d3ccf8620dfa2e6"
     ]
   },
@@ -3703,7 +3703,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zUSDC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x8d35beb9e8750959c3520d202b589ab78c366d59",
+      "https://snowtrace.io/address/0x8d35beb9e8750959c3520d202b589ab78c366d59",
       "https://avascan.info/blockchain/c/address/0x8d35beb9e8750959c3520d202b589ab78c366d59"
     ]
   },
@@ -3715,7 +3715,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zUSDC LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x141be6e009a0d9a5c0d4e557c0636e97b3de2a7b",
+      "https://snowtrace.io/address/0x141be6e009a0d9a5c0d4e557c0636e97b3de2a7b",
       "https://avascan.info/blockchain/c/address/0x141be6e009a0d9a5c0d4e557c0636e97b3de2a7b"
     ]
   },
@@ -3727,7 +3727,7 @@
     "type": "core",
     "description": "ZERO farm for ZERO-zUSDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9800f6189ee6849361d8bf4c0cd7a75a3074550d",
+      "https://snowtrace.io/address/0x9800f6189ee6849361d8bf4c0cd7a75a3074550d",
       "https://avascan.info/blockchain/c/address/0x9800f6189ee6849361d8bf4c0cd7a75a3074550d"
     ]
   },
@@ -3739,7 +3739,7 @@
     "type": "core",
     "description": "sGLB farm for AVAX-LINK LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x829a96afacb3f39f740b39fdf575658f88b153f1",
+      "https://snowtrace.io/address/0x829a96afacb3f39f740b39fdf575658f88b153f1",
       "https://avascan.info/blockchain/c/address/0x829a96afacb3f39f740b39fdf575658f88b153f1"
     ]
   },
@@ -3751,7 +3751,7 @@
     "type": "core",
     "description": "sGLB farm for AVAX-USDT LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1e3808e065280e5d773e7d1e9d1f8421c4543b27",
+      "https://snowtrace.io/address/0x1e3808e065280e5d773e7d1e9d1f8421c4543b27",
       "https://avascan.info/blockchain/c/address/0x1e3808e065280e5d773e7d1e9d1f8421c4543b27"
     ]
   },
@@ -3763,7 +3763,7 @@
     "type": "core",
     "description": "sGLB farm for ETH-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x855f76f69826b41d663da8587c199e5ff4c55325",
+      "https://snowtrace.io/address/0x855f76f69826b41d663da8587c199e5ff4c55325",
       "https://avascan.info/blockchain/c/address/0x855f76f69826b41d663da8587c199e5ff4c55325"
     ]
   },
@@ -3775,7 +3775,7 @@
     "type": "core",
     "description": "sGLB farm for PNG-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xeec2d8bd006e189a0e53819c670b9c08ee098eb0",
+      "https://snowtrace.io/address/0xeec2d8bd006e189a0e53819c670b9c08ee098eb0",
       "https://avascan.info/blockchain/c/address/0xeec2d8bd006e189a0e53819c670b9c08ee098eb0"
     ]
   },
@@ -3787,7 +3787,7 @@
     "type": "core",
     "description": "sGLB farm for SUSHI-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xa75af2e0ea2bbda6dc6921b4ee3bb051309d28c9",
+      "https://snowtrace.io/address/0xa75af2e0ea2bbda6dc6921b4ee3bb051309d28c9",
       "https://avascan.info/blockchain/c/address/0xa75af2e0ea2bbda6dc6921b4ee3bb051309d28c9"
     ]
   },
@@ -3799,7 +3799,7 @@
     "type": "core",
     "description": "xPARTY farm for PARTY-AVAX LP",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x9cfe241015d21c3d8290a1b59205e5d0c2f7f421",
+      "https://snowtrace.io/address/0x9cfe241015d21c3d8290a1b59205e5d0c2f7f421",
       "https://avascan.info/blockchain/c/address/0x9cfe241015d21c3d8290a1b59205e5d0c2f7f421"
     ]
   },
@@ -3811,7 +3811,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x5929cdde7c7715d3e42f577e5cadcf2c2d246c52",
+      "https://snowtrace.io/address/0x5929cdde7c7715d3e42f577e5cadcf2c2d246c52",
       "https://avascan.info/blockchain/c/address/0x5929cdde7c7715d3e42f577e5cadcf2c2d246c52"
     ]
   },
@@ -3823,7 +3823,7 @@
     "type": "governance",
     "description": "Voting power formula for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x460c1d4d448ce463bd0b134ac25f3e27ed015e97",
+      "https://snowtrace.io/address/0x460c1d4d448ce463bd0b134ac25f3e27ed015e97",
       "https://avascan.info/blockchain/c/address/0x460c1d4d448ce463bd0b134ac25f3e27ed015e97"
     ]
   },
@@ -3835,7 +3835,7 @@
     "type": "governance",
     "description": "Voting power formula for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0826ec0b93eed1d8e7f36dfa2ec592abd37078a8",
+      "https://snowtrace.io/address/0x0826ec0b93eed1d8e7f36dfa2ec592abd37078a8",
       "https://avascan.info/blockchain/c/address/0x0826ec0b93eed1d8e7f36dfa2ec592abd37078a8"
     ]
   },
@@ -3847,7 +3847,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xcb031c1044f27bb491e61bcbd96a54f5316e23ef",
+      "https://snowtrace.io/address/0xcb031c1044f27bb491e61bcbd96a54f5316e23ef",
       "https://avascan.info/blockchain/c/address/0xcb031c1044f27bb491e61bcbd96a54f5316e23ef"
     ]
   },
@@ -3859,7 +3859,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x0cf605484a512d3f3435fed77ab5ddc0525daf5f",
+      "https://snowtrace.io/address/0x0cf605484a512d3f3435fed77ab5ddc0525daf5f",
       "https://avascan.info/blockchain/c/address/0x0cf605484a512d3f3435fed77ab5ddc0525daf5f"
     ]
   },
@@ -3871,7 +3871,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x6662a6b70316ae373b56855b2cda521c59f6e2c2",
+      "https://snowtrace.io/address/0x6662a6b70316ae373b56855b2cda521c59f6e2c2",
       "https://avascan.info/blockchain/c/address/0x6662a6b70316ae373b56855b2cda521c59f6e2c2"
     ]
   },
@@ -3883,7 +3883,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x77f227c5828f38596081dc03519dec8606211bef",
+      "https://snowtrace.io/address/0x77f227c5828f38596081dc03519dec8606211bef",
       "https://avascan.info/blockchain/c/address/0x77f227c5828f38596081dc03519dec8606211bef"
     ]
   },
@@ -3895,7 +3895,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1a89939f66a04e61ab2389851b7d9dc483e6fd35",
+      "https://snowtrace.io/address/0x1a89939f66a04e61ab2389851b7d9dc483e6fd35",
       "https://avascan.info/blockchain/c/address/0x1a89939f66a04e61ab2389851b7d9dc483e6fd35"
     ]
   },
@@ -3907,7 +3907,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2160dec25eccb5f9a8af38061b3ad1b828018abb",
+      "https://snowtrace.io/address/0x2160dec25eccb5f9a8af38061b3ad1b828018abb",
       "https://avascan.info/blockchain/c/address/0x2160dec25eccb5f9a8af38061b3ad1b828018abb"
     ]
   },
@@ -3919,7 +3919,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x56894d9e63659314cabccb600fda8116ecdbacf2",
+      "https://snowtrace.io/address/0x56894d9e63659314cabccb600fda8116ecdbacf2",
       "https://avascan.info/blockchain/c/address/0x56894d9e63659314cabccb600fda8116ecdbacf2"
     ]
   },
@@ -3931,7 +3931,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x2ccc71d0a32ce41e260cc67e68986113cce27f20",
+      "https://snowtrace.io/address/0x2ccc71d0a32ce41e260cc67e68986113cce27f20",
       "https://avascan.info/blockchain/c/address/0x2ccc71d0a32ce41e260cc67e68986113cce27f20"
     ]
   },
@@ -3943,7 +3943,7 @@
     "type": "governance",
     "description": "Governance contracts for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x1ba4f0a66445777ae0be89dcb72316c9f02cc75a",
+      "https://snowtrace.io/address/0x1ba4f0a66445777ae0be89dcb72316c9f02cc75a",
       "https://avascan.info/blockchain/c/address/0x1ba4f0a66445777ae0be89dcb72316c9f02cc75a"
     ]
   },
@@ -3955,7 +3955,7 @@
     "type": "governance",
     "description": "Governance token for yield yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0x59414b3089ce2af0010e7523dea7e2b35d776ec7",
+      "https://snowtrace.io/address/0x59414b3089ce2af0010e7523dea7e2b35d776ec7",
       "https://avascan.info/blockchain/c/address/0x59414b3089ce2af0010e7523dea7e2b35d776ec7"
     ]
   },
@@ -3967,7 +3967,7 @@
     "type": "core",
     "description": "A mYak is one-million-th Yak",
     "explorers": [
-      "https://cchain.explorer.avax.network/address/0xddaaad7366b455aff8e7c82940c43ceb5829b604",
+      "https://snowtrace.io/address/0xddaaad7366b455aff8e7c82940c43ceb5829b604",
       "https://avascan.info/blockchain/c/address/0xddaaad7366b455aff8e7c82940c43ceb5829b604"
     ]
   }


### PR DESCRIPTION
Ava Labs recently announced Snowtrace. A blockchain explorer build a la Etherscan that will replace the old cchain.explorer .

https://medium.com/avalancheavax/snowtrace-bringing-etherscan-to-the-avalanche-community-f8463e0d80d3

The old one (used at the moment in this doc) will be deprecated in a few days.

https://testnet.snowtrace.io/
https://snowtrace.io/